### PR TITLE
Fix issue with brew install path

### DIFF
--- a/src/serviceprovider/system/main.go
+++ b/src/serviceprovider/system/main.go
@@ -56,7 +56,7 @@ func (s *SystemService) Name() string {
 
 func (s *SystemService) FindPath() string {
 	s.ctx.LogInfo("Getting brew executable")
-	out, err := commands.ExecuteWithNoOutput("which", "packer")
+	out, err := commands.ExecuteWithNoOutput("which", "brew")
 	path := strings.ReplaceAll(strings.TrimSpace(out), "\n", "")
 	if err != nil || path == "" {
 		s.ctx.LogWarn("Brew executable not found, trying to find it in the default locations")

--- a/src/startup/main.go
+++ b/src/startup/main.go
@@ -32,7 +32,7 @@ func Init(ctx basecontext.ApiContext) {
 func Start(ctx basecontext.ApiContext) {
 	cfg := config.Get()
 
-	system := system.New(ctx)
+	system := system.SystemService{}
 	if system.GetOperatingSystem() != "macos" {
 		serviceprovider.InitCatalogServices(ctx)
 	} else {

--- a/src/startup/seeds/packertemplates/macos_14_0.go
+++ b/src/startup/seeds/packertemplates/macos_14_0.go
@@ -37,16 +37,16 @@ func AddMacOs14_0Manual(ctx *basecontext.BaseContext, svc *data.JsonDatabase) er
 	}
 
 	if err := ubuntu2304Template.Validate(); err != nil {
-		common.Logger.Error("Error validating Kali Linux 2023.3 template: %s", err.Error())
+		common.Logger.Error("Error validating macOS Sonoma 14.0 template: %s", err.Error())
 		return err
 	} else {
 		if _, err := svc.AddPackerTemplate(ctx, &ubuntu2304Template); err != nil {
 			if err.Error() != data.ErrPackerTemplateAlreadyExists.Error() {
-				common.Logger.Error("Error adding Kali Linux 2023.3 template: %s", err.Error())
+				common.Logger.Error("Error adding macOS Sonoma 14.0 template: %s", err.Error())
 				return err
 			}
 		} else {
-			common.Logger.Info("Kali Linux 2023.3 template added")
+			common.Logger.Info("macOS Sonoma 14.0 template added")
 		}
 	}
 


### PR DESCRIPTION
# Description

- Fixed an issue where the brew detector was not looking into the right path
- Fixed an issue where the log line for the macOs Sonoma template was wrong
- Fixed an issue where the brew log line was showing duplicated at starup

Fixes #98 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md file accordingly
