### PR TITLE
Added ability to remove database on uninstall

### DIFF
--- a/src/cmd/uninstall.go
+++ b/src/cmd/uninstall.go
@@ -5,10 +5,15 @@ import (
 
 	"github.com/Parallels/prl-devops-service/basecontext"
 	"github.com/Parallels/prl-devops-service/install"
+	"github.com/cjlapao/common-go/helper"
 )
 
 func processUninstall(ctx basecontext.ApiContext) {
-	if err := install.UninstallService(ctx); err != nil {
+	removeDatabase := false
+	if helper.GetFlagSwitch("full", false) {
+		removeDatabase = true
+	}
+	if err := install.UninstallService(ctx, removeDatabase); err != nil {
 		ctx.LogErrorf(err.Error())
 		os.Exit(1)
 	}

--- a/src/config/main.go
+++ b/src/config/main.go
@@ -253,7 +253,7 @@ func (c *Config) RootFolder() (string, error) {
 	}
 
 	if currentUser == "root" {
-		folder := "/etc/parallels-api-service"
+		folder := constants.ServiceDefaultDirectory
 		err := helpers.CreateDirIfNotExist(folder)
 		if err != nil {
 			return "", err

--- a/src/constants/main.go
+++ b/src/constants/main.go
@@ -4,7 +4,8 @@ type AuthorizationContextKey string
 
 var (
 	Name                                              = "Parallels Desktop DevOps Service"
-	ExecutableName                                    = "prldevops"
+	ExecutableName                                    = "parallels-devops-service"
+	ServiceDefaultDirectory                           = "/etc/prl-devops-service"
 	AUTHORIZATION_CONTEXT_KEY AuthorizationContextKey = "AUTHORIZATION_CONTEXT"
 )
 

--- a/src/install/main.go
+++ b/src/install/main.go
@@ -47,14 +47,14 @@ func InstallService(ctx basecontext.ApiContext, configFilePath string) error {
 	}
 }
 
-func UninstallService(ctx basecontext.ApiContext) error {
+func UninstallService(ctx basecontext.ApiContext, removeDatabase bool) error {
 	switch os := runtime.GOOS; os {
 	case "darwin":
-		return uninstallServiceOnMac(ctx)
+		return uninstallServiceOnMac(ctx, removeDatabase)
 	case "windows":
-		return uninstallServiceOnWindows(ctx)
+		return uninstallServiceOnWindows(ctx, removeDatabase)
 	case "linux":
-		return uninstallServiceOnLinux(ctx)
+		return uninstallServiceOnLinux(ctx, removeDatabase)
 	default:
 		errMsg := fmt.Sprintf("unsupported operating system: %s", os)
 		ctx.LogErrorf(errMsg)
@@ -85,7 +85,7 @@ func installServiceOnMac(ctx basecontext.ApiContext, config ApiServiceConfig) er
 
 	// Unload the daemon if it is already loaded
 	if helper.FileExists(daemonPath) {
-		if err := uninstallServiceOnMac(ctx); err != nil {
+		if err := uninstallServiceOnMac(ctx, false); err != nil {
 			return err
 		}
 	}
@@ -123,7 +123,7 @@ func installServiceOnMac(ctx basecontext.ApiContext, config ApiServiceConfig) er
 	return nil
 }
 
-func uninstallServiceOnMac(ctx basecontext.ApiContext) error {
+func uninstallServiceOnMac(ctx basecontext.ApiContext, removeDatabase bool) error {
 	daemonPath := filepath.Join(MAC_PLIST_DAEMON_PATH, MAC_PLIST_DAEMON_NAME)
 
 	cmd := helpers.Command{
@@ -139,6 +139,12 @@ func uninstallServiceOnMac(ctx basecontext.ApiContext) error {
 		return err
 	}
 
+	if removeDatabase && helper.FileExists(constants.ServiceDefaultDirectory) {
+		if err := os.RemoveAll(constants.ServiceDefaultDirectory); err != nil {
+			return err
+		}
+	}
+
 	ctx.LogInfof("Service uninstalled successfully")
 	return nil
 }
@@ -147,7 +153,7 @@ func installServiceOnWindows(ctx basecontext.ApiContext, config ApiServiceConfig
 	return errors.New("not implemented")
 }
 
-func uninstallServiceOnWindows(ctx basecontext.ApiContext) error {
+func uninstallServiceOnWindows(ctx basecontext.ApiContext, removeDatabase bool) error {
 	return errors.New("not implemented")
 }
 
@@ -155,7 +161,7 @@ func installServiceOnLinux(ctx basecontext.ApiContext, config ApiServiceConfig) 
 	return nil
 }
 
-func uninstallServiceOnLinux(ctx basecontext.ApiContext) error {
+func uninstallServiceOnLinux(ctx basecontext.ApiContext, removeDatabase bool) error {
 	return nil
 }
 

--- a/src/serviceprovider/main.go
+++ b/src/serviceprovider/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Parallels/prl-devops-service/basecontext"
 	"github.com/Parallels/prl-devops-service/common"
 	"github.com/Parallels/prl-devops-service/config"
+	"github.com/Parallels/prl-devops-service/constants"
 	"github.com/Parallels/prl-devops-service/data"
 	"github.com/Parallels/prl-devops-service/errors"
 	"github.com/Parallels/prl-devops-service/helpers"
@@ -146,7 +147,7 @@ func InitServices(ctx basecontext.ApiContext) {
 	globalProvider.RunningUser = currentUser
 
 	if globalProvider.RunningUser == "root" {
-		dbLocation := "/etc/parallels-api-service"
+		dbLocation := constants.ServiceDefaultDirectory
 		err := helpers.CreateDirIfNotExist(dbLocation)
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
# Description

-  Added a flag `--full` to uninstall to fully remove the database when uninstalling
- Changed the default installation for the database folder under root

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

### Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md file accordingly
