### PR TITLE
initial fixes for 0.8 hotfix

### DIFF
--- a/.github/workflows/publish_beta.yml
+++ b/.github/workflows/publish_beta.yml
@@ -1,0 +1,156 @@
+name: Publish Beta Release
+
+on:
+  push:
+    tags:
+      - '*_beta'
+
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release"
+        required: true
+
+jobs:
+  check-version-change:
+    outputs:
+      changed: ${{ steps.check-version.outputs.result }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check if version has changed
+        id: check-version
+        uses: actions/github-script@v6
+        with:
+          script: |
+            // Get the version from the workflow input
+            let version = '${{ github.event.inputs.version }}';
+            if (!version) {
+              fs = require('fs');
+              let v = '';
+              try {
+                v = fs.readFileSync('./VERSION', 'utf8');
+                console.log(`Version found: ${v}`);
+              }
+              catch (err) {
+                return false;
+              }
+          
+              if (!v) {
+                return false;
+              } else {
+                version = v;
+              }
+            }
+
+            // Find a release for that version
+            const release = await github.rest.repos.getReleaseByTag({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag: `v${version}-beta`,
+            }).catch(() => null);
+
+            // If the release exists, the version has not changed
+            if (release) {
+              console.log(`Version ${version} has an existing release`);
+              console.log(release.data.html_url);
+              core.summary.addLink(`Release v${version}`, release.data.html_url);
+              await core.summary.write();
+              return "false";
+            }
+            console.log(`Version ${version} does not have a release`);
+            return true;
+  release:
+    needs: check-version-change
+    if: ${{ needs.check-version-change.outputs.changed == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: read
+    env:
+      EXT_VERSION: "" # will be set in the workflow
+    outputs:
+      version: ${{ env.EXT_VERSION }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Parse version from package.json
+        run: |
+          echo "EXT_VERSION=$(cat ./VERSION)" >> "$GITHUB_ENV"
+      - name: Create release and upload release asset
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const fs = require("fs");
+            const release = await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: "v${{ env.EXT_VERSION }}-beta",
+              name: "v${{ env.EXT_VERSION }}",
+              draft: false,
+              prerelease: true
+            });
+
+            core.summary.addLink(`Release v${{ env.EXT_VERSION }}`, release.data.html_url);
+            await core.summary.write();
+  releases-matrix:
+    needs: release
+    name: Release Go Binary
+    runs-on: ubuntu-latest
+    env:
+      EXT_VERSION: ${{ needs.release.outputs.version }}
+      AmplitudeApiKey: ${{ secrets.AMPLITUDE_API_KEY }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # build and publish in parallel: linux/386, linux/amd64, linux/arm64, windows/386, windows/amd64, darwin/amd64, darwin/arm64
+        goos: [linux, windows, darwin]
+        goarch: ["386", amd64, arm64]
+        exclude:
+          - goarch: "386"
+            goos: darwin
+    steps:
+    - uses: actions/checkout@v3
+    - name: Add Inbuilt Variables
+      run: |
+        sed -i "s/var AmplitudeApiKey = \"\"/var AmplitudeApiKey = \"${{ env.AmplitudeApiKey }}\"/g" ./src/constants/amplitude.go
+
+    - uses: wangyoucao577/go-release-action@v1
+      timeout-minutes: 10
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        goos: ${{ matrix.goos }}
+        goarch: ${{ matrix.goarch }}
+        goversion: "https://dl.google.com/go/go1.21.1.linux-amd64.tar.gz"
+        project_path: "./src"
+        binary_name: "prldevops"
+        release_name: "v${{ env.EXT_VERSION }}"
+
+  build-containers:
+    needs: release
+    env:
+      EXT_VERSION: ${{ needs.release.outputs.version }}
+      AmplitudeApiKey: ${{ secrets.AMPLITUDE_API_KEY }}
+    name: Build Docker Images
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Add Inbuilt Variables
+      run: |
+        sed -i "s/var AmplitudeApiKey = \"\"/var AmplitudeApiKey = \"${{ env.AmplitudeApiKey }}\"/g" ./src/constants/amplitude.go
+    - uses: docker/setup-buildx-action@v1
+    - uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+    - uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: ./Dockerfile
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: |
+          ${{ secrets.DOCKER_USERNAME }}/prl-devops-service:latest
+          ${{ secrets.DOCKER_USERNAME }}/prl-devops-service:${{ env.EXT_VERSION }}
+        

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [0.8.0] - 2024-06-03
+
+### Fixed
+
+- Fixed an issue where we were trying to get the virtual machines for other users
+  when not being a super admin
+  
+### Changed
+
+- Moved database saving process to a 5 minutes setting to avoid overloading the
+  database with too many requests
+- Changed the way the orchestrator was checking for VMs status changes to avoid
+  overloading the database
+- Moved all the old commands to the new exec with context to enable timeouts
+- Added a 30 seconds timeout when checking the status of the local vms
+  
 ## [0.7.1] - 2024-05-29
 
 ### Added

--- a/src/controllers/performance.go
+++ b/src/controllers/performance.go
@@ -20,7 +20,6 @@ func registerPerformanceHandlers(ctx basecontext.ApiContext, version string) {
 		WithVersion(version).WithPath("/performance/db").
 		WithHandler(PerformDbTestHandler()).
 		Register()
-
 }
 
 func PerformDbTestHandler() restapi.ControllerHandler {
@@ -57,7 +56,7 @@ func PerformDbTestHandler() restapi.ControllerHandler {
 		for i := 0; i < request.TestCount; i++ {
 			ctx.LogInfof("This is a test log")
 			for j := 0; j < request.ConsecutiveCalls; j++ {
-				go dbService.Save(ctx)
+				go dbService.SaveNow(ctx)
 				if request.TimeBetweenConsecutiveCalls > 0 {
 					time.Sleep(time.Duration(request.TimeBetweenConsecutiveCalls) * time.Millisecond)
 				}

--- a/src/data/backup.go
+++ b/src/data/backup.go
@@ -1,0 +1,64 @@
+package data
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Parallels/prl-devops-service/basecontext"
+	"github.com/cjlapao/common-go/helper"
+)
+
+func (j *JsonDatabase) Backup(ctx basecontext.ApiContext) error {
+	backupFiles, err := findBackupFiles(j.filename)
+	if err != nil {
+		ctx.LogErrorf("[Database] Error finding backup files: %v", err)
+		return err
+	}
+
+	if len(backupFiles) >= j.Config.NumberOfBackupFiles {
+		// Delete the oldest backup file
+		oldestFile := backupFiles[0]
+		err := os.Remove(oldestFile)
+		if err != nil {
+			ctx.LogErrorf("[Database] Error deleting backup file: %v", err)
+			return err
+		}
+	}
+
+	// Create a new backup file with timestamp
+	timestamp := time.Now().Format("20060102150405")
+	newBackupFile := fmt.Sprintf("%s.save.bak.%s", j.filename, timestamp)
+	err = helper.CopyFile(j.filename, newBackupFile)
+	if err != nil {
+		ctx.LogErrorf("[Database] Error creating new backup file: %v", err)
+		return err
+	}
+
+	return nil
+}
+
+func findBackupFiles(filename string) ([]string, error) {
+	dir := filepath.Dir(filename)
+	base := filepath.Base(filename)
+	pattern := fmt.Sprintf("%s.save.bak.*", base)
+	matches, err := filepath.Glob(filepath.Join(dir, pattern))
+	if err != nil {
+		return nil, err
+	}
+
+	// Sort the backup files by timestamp
+	sort.Slice(matches, func(i, j int) bool {
+		return extractTimestamp(matches[i]) < extractTimestamp(matches[j])
+	})
+
+	return matches, nil
+}
+
+func extractTimestamp(filename string) string {
+	parts := strings.Split(filename, ".")
+	return parts[len(parts)-1]
+}

--- a/src/data/catalog.go
+++ b/src/data/catalog.go
@@ -221,10 +221,6 @@ func (j *JsonDatabase) CreateCatalogManifest(ctx basecontext.ApiContext, manifes
 	manifest.UpdatedAt = helpers.GetUtcCurrentDateTime()
 
 	j.data.ManifestsCatalog = append(j.data.ManifestsCatalog, manifest)
-
-	if err := j.Save(ctx); err != nil {
-		return nil, err
-	}
 	return &manifest, nil
 }
 
@@ -237,7 +233,6 @@ func (j *JsonDatabase) DeleteCatalogManifest(ctx basecontext.ApiContext, catalog
 		return ErrCatalogManifestNotFound
 	}
 
-	found := false
 	for {
 		catalogManifests, err := j.GetCatalogManifests(ctx, "")
 		if err != nil {
@@ -253,7 +248,6 @@ func (j *JsonDatabase) DeleteCatalogManifest(ctx basecontext.ApiContext, catalog
 				}
 				j.data.ManifestsCatalog = append(j.data.ManifestsCatalog[:index], j.data.ManifestsCatalog[index+1:]...)
 				deletedSomething = true
-				found = true
 				break
 			}
 		}
@@ -261,13 +255,6 @@ func (j *JsonDatabase) DeleteCatalogManifest(ctx basecontext.ApiContext, catalog
 		if !deletedSomething {
 			break
 		}
-	}
-
-	if found {
-		if err := j.Save(ctx); err != nil {
-			return err
-		}
-		return nil
 	}
 
 	return ErrCatalogManifestNotFound
@@ -296,9 +283,6 @@ func (j *JsonDatabase) DeleteCatalogManifestVersion(ctx basecontext.ApiContext, 
 		if (strings.EqualFold(manifest.ID, catalogIdOrId) || strings.EqualFold(manifest.CatalogId, catalogIdOrId)) &&
 			strings.EqualFold(manifest.Version, version) {
 			j.data.ManifestsCatalog = append(j.data.ManifestsCatalog[:i], j.data.ManifestsCatalog[i+1:]...)
-			if err := j.Save(ctx); err != nil {
-				return err
-			}
 			return nil
 		}
 	}
@@ -329,9 +313,6 @@ func (j *JsonDatabase) DeleteCatalogManifestVersionArch(ctx basecontext.ApiConte
 				continue
 			}
 			j.data.ManifestsCatalog = append(j.data.ManifestsCatalog[:i], j.data.ManifestsCatalog[i+1:]...)
-			if err := j.Save(ctx); err != nil {
-				return err
-			}
 			return nil
 		}
 	}
@@ -370,9 +351,6 @@ func (j *JsonDatabase) UpdateCatalogManifest(ctx basecontext.ApiContext, record 
 			j.data.ManifestsCatalog[i].RequiredClaims = record.RequiredClaims
 			j.data.ManifestsCatalog[i].RequiredRoles = record.RequiredRoles
 
-			if err := j.Save(ctx); err != nil {
-				return nil, err
-			}
 			return &j.data.ManifestsCatalog[i], nil
 		}
 	}
@@ -389,9 +367,6 @@ func (j *JsonDatabase) UpdateCatalogManifestTags(ctx basecontext.ApiContext, rec
 		if strings.EqualFold(manifest.ID, record.ID) || (strings.EqualFold(manifest.CatalogId, record.CatalogId) && strings.EqualFold(manifest.Version, record.Version)) {
 			j.data.ManifestsCatalog[i].Tags = record.Tags
 
-			if err := j.Save(ctx); err != nil {
-				return err
-			}
 			return nil
 		}
 	}
@@ -420,9 +395,6 @@ func (j *JsonDatabase) UpdateCatalogManifestRequiredRoles(ctx basecontext.ApiCon
 				}
 			}
 
-			if err := j.Save(ctx); err != nil {
-				return err
-			}
 			return nil
 		}
 	}
@@ -462,9 +434,6 @@ func (j *JsonDatabase) AddCatalogManifestRequiredClaims(ctx basecontext.ApiConte
 				}
 			}
 
-			if err := j.Save(ctx); err != nil {
-				return err
-			}
 			return nil
 		}
 	}
@@ -491,10 +460,6 @@ func (j *JsonDatabase) RemoveCatalogManifestRequiredClaims(ctx basecontext.ApiCo
 				if foundAt != -1 {
 					j.data.ManifestsCatalog[i].RequiredClaims = append(j.data.ManifestsCatalog[i].RequiredClaims[:foundAt], j.data.ManifestsCatalog[i].RequiredClaims[foundAt+1:]...)
 				}
-			}
-
-			if err := j.Save(ctx); err != nil {
-				return err
 			}
 			return nil
 		}
@@ -535,9 +500,6 @@ func (j *JsonDatabase) AddCatalogManifestRequiredRoles(ctx basecontext.ApiContex
 				}
 			}
 
-			if err := j.Save(ctx); err != nil {
-				return err
-			}
 			return nil
 		}
 	}
@@ -566,9 +528,6 @@ func (j *JsonDatabase) RemoveCatalogManifestRequiredRoles(ctx basecontext.ApiCon
 				}
 			}
 
-			if err := j.Save(ctx); err != nil {
-				return err
-			}
 			return nil
 		}
 	}
@@ -597,9 +556,6 @@ func (j *JsonDatabase) AddCatalogManifestTags(ctx basecontext.ApiContext, record
 				}
 			}
 
-			if err := j.Save(ctx); err != nil {
-				return err
-			}
 			return nil
 		}
 	}
@@ -628,9 +584,6 @@ func (j *JsonDatabase) RemoveCatalogManifestTags(ctx basecontext.ApiContext, rec
 				}
 			}
 
-			if err := j.Save(ctx); err != nil {
-				return err
-			}
 			return nil
 		}
 	}
@@ -655,9 +608,6 @@ func (j *JsonDatabase) UpdateCatalogManifestDownloadCount(ctx basecontext.ApiCon
 			j.data.ManifestsCatalog[i].LastDownloadedUser = downloadUser
 			j.data.ManifestsCatalog[i].DownloadCount = j.data.ManifestsCatalog[i].DownloadCount + 1
 
-			if err := j.Save(ctx); err != nil {
-				return err
-			}
 			return nil
 		}
 	}
@@ -682,9 +632,6 @@ func (j *JsonDatabase) TaintCatalogManifestVersion(ctx basecontext.ApiContext, c
 			j.data.ManifestsCatalog[i].Tainted = true
 			j.data.ManifestsCatalog[i].TaintedBy = taintUser
 
-			if err := j.Save(ctx); err != nil {
-				return nil, err
-			}
 			return &j.data.ManifestsCatalog[i], nil
 		}
 	}
@@ -710,9 +657,6 @@ func (j *JsonDatabase) UnTaintCatalogManifestVersion(ctx basecontext.ApiContext,
 			j.data.ManifestsCatalog[i].UnTaintedBy = unTaintUser
 			j.data.ManifestsCatalog[i].TaintedBy = ""
 
-			if err := j.Save(ctx); err != nil {
-				return nil, err
-			}
 			return &j.data.ManifestsCatalog[i], nil
 		}
 	}
@@ -737,9 +681,6 @@ func (j *JsonDatabase) RevokeCatalogManifestVersion(ctx basecontext.ApiContext, 
 			j.data.ManifestsCatalog[i].Revoked = true
 			j.data.ManifestsCatalog[i].RevokedBy = revokeUser
 
-			if err := j.Save(ctx); err != nil {
-				return nil, err
-			}
 			return &j.data.ManifestsCatalog[i], nil
 		}
 	}

--- a/src/data/claims.go
+++ b/src/data/claims.go
@@ -71,9 +71,6 @@ func (j *JsonDatabase) CreateClaim(ctx basecontext.ApiContext, claim models.Clai
 	}
 
 	j.data.Claims = append(j.data.Claims, claim)
-	if err := j.Save(ctx); err != nil {
-		return nil, err
-	}
 
 	return &claim, nil
 }
@@ -101,9 +98,7 @@ func (j *JsonDatabase) DeleteClaim(ctx basecontext.ApiContext, idOrName string) 
 					}
 				}
 			}
-			if err := j.Save(ctx); err != nil {
-				return err
-			}
+
 			return nil
 		}
 	}
@@ -135,9 +130,7 @@ func (j *JsonDatabase) UpdateClaim(ctx basecontext.ApiContext, claim *models.Cla
 					}
 				}
 			}
-			if err := j.Save(ctx); err != nil {
-				return nil, err
-			}
+
 			return claim, nil
 		}
 	}

--- a/src/data/diff.go
+++ b/src/data/diff.go
@@ -1,0 +1,16 @@
+package data
+
+import "encoding/json"
+
+func Diff(a interface{}, b interface{}) bool {
+	jsonA, err := json.Marshal(a)
+	if err != nil {
+		return false
+	}
+	jsonB, err := json.Marshal(b)
+	if err != nil {
+		return false
+	}
+
+	return string(jsonA) != string(jsonB)
+}

--- a/src/data/main.go
+++ b/src/data/main.go
@@ -82,7 +82,9 @@ func NewJsonDatabase(ctx basecontext.ApiContext, filename string) *JsonDatabase 
 	_ = memoryDatabase.Load(rootContext)
 
 	memoryDatabase.cancel = make(chan bool)
-	memoryDatabase.Save1(ctx)
+	if err := memoryDatabase.SaveAsync(ctx); err != nil {
+		ctx.LogErrorf("[Database] Error saving database: %v", err)
+	}
 	return memoryDatabase
 }
 
@@ -233,7 +235,7 @@ func (j *JsonDatabase) SaveAs(ctx basecontext.ApiContext, filename string) error
 	return nil
 }
 
-func (j *JsonDatabase) Save1(ctx basecontext.ApiContext) error {
+func (j *JsonDatabase) SaveAsync(ctx basecontext.ApiContext) error {
 	defer func() {
 		if r := recover(); r != nil {
 			ctx.LogErrorf("[Database] Panic occurred during save: %v", r)

--- a/src/data/main.go
+++ b/src/data/main.go
@@ -5,11 +5,13 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 
 	"github.com/Parallels/prl-devops-service/basecontext"
 	"github.com/Parallels/prl-devops-service/config"
 	"github.com/Parallels/prl-devops-service/data/models"
 	"github.com/Parallels/prl-devops-service/errors"
+	"github.com/Parallels/prl-devops-service/helpers"
 	"github.com/Parallels/prl-devops-service/security"
 
 	"github.com/cjlapao/common-go/helper"
@@ -39,21 +41,35 @@ type Data struct {
 }
 
 type JsonDatabase struct {
+	ctx         basecontext.ApiContext
+	Config      JsonDatabaseConfig
 	connected   bool
 	isSaving    bool
 	saveProcess chan bool
 	filename    string
 	saveMutex   sync.Mutex
-	saveQueue   []saveRequest
+	cancel      chan bool
 	data        Data
 }
 
-func NewJsonDatabase(filename string) *JsonDatabase {
+type JsonDatabaseConfig struct {
+	DatabaseFilename    string        `json:"database_filename"`
+	NumberOfBackupFiles int           `json:"number_of_backup_files"`
+	SaveInterval        time.Duration `json:"save_interval"`
+}
+
+func NewJsonDatabase(ctx basecontext.ApiContext, filename string) *JsonDatabase {
 	if memoryDatabase != nil {
 		return memoryDatabase
 	}
 
 	memoryDatabase = &JsonDatabase{
+		Config: JsonDatabaseConfig{
+			DatabaseFilename:    filename,
+			NumberOfBackupFiles: 10,
+			SaveInterval:        5 * time.Minute,
+		},
+		ctx:         ctx,
 		connected:   false,
 		isSaving:    false,
 		filename:    filename,
@@ -65,6 +81,8 @@ func NewJsonDatabase(filename string) *JsonDatabase {
 	rootContext := basecontext.NewRootBaseContext()
 	_ = memoryDatabase.Load(rootContext)
 
+	memoryDatabase.cancel = make(chan bool)
+	memoryDatabase.Save1(ctx)
 	return memoryDatabase
 }
 
@@ -98,13 +116,21 @@ func (j *JsonDatabase) Load(ctx basecontext.ApiContext) error {
 
 	defer file.Close()
 
-	fileInfo, err := os.Stat(j.filename)
 	if err != nil {
 		ctx.LogErrorf("[Database] Error getting database file info: %v", err)
 		return err
 	}
 
-	if fileInfo.Size() == 0 {
+	isEmpty := false
+	fileContent, err := helper.ReadFromFile(j.filename)
+	if err != nil {
+		isEmpty = true
+	}
+	if fileContent == nil || len(fileContent) == 0 {
+		isEmpty = true
+	}
+
+	if isEmpty {
 		ctx.LogInfof("[Database] Database file is empty, creating new file")
 		j.data = Data{
 			Users:            make([]models.User, 0),
@@ -115,7 +141,7 @@ func (j *JsonDatabase) Load(ctx basecontext.ApiContext) error {
 			ManifestsCatalog: make([]models.CatalogManifest, 0),
 		}
 
-		err = j.Save(ctx)
+		err = j.SaveNow(ctx)
 		if err != nil {
 			ctx.LogErrorf("[Database] Error saving database file: %v", err)
 			return err
@@ -127,11 +153,8 @@ func (j *JsonDatabase) Load(ctx basecontext.ApiContext) error {
 		ctx.LogInfof("[Database] Database file is not empty, loading data")
 
 		// Backup the file before attempting to read it
-		backupFilename := j.filename + ".bak"
-		err := helper.CopyFile(j.filename, backupFilename)
-		if err != nil {
-			ctx.LogErrorf("[Database] Error creating backup file: %v", err)
-			return err
+		if err := j.Backup(ctx); err != nil {
+			ctx.LogErrorf("[Database] Error managing backup files: %v", err)
 		}
 
 		content, err := helper.ReadFromFile(j.filename)
@@ -187,11 +210,6 @@ func (j *JsonDatabase) IsConnected() bool {
 	return j.connected
 }
 
-type saveRequest struct {
-	ctx basecontext.ApiContext
-	wg  *sync.WaitGroup
-}
-
 func (j *JsonDatabase) SaveAs(ctx basecontext.ApiContext, filename string) error {
 	oldFilename := j.filename
 	baseDbDir := filepath.Dir(oldFilename)
@@ -215,21 +233,48 @@ func (j *JsonDatabase) SaveAs(ctx basecontext.ApiContext, filename string) error
 	return nil
 }
 
-func (j *JsonDatabase) Save(ctx basecontext.ApiContext) error {
-	totalSaveRequests++
-
-	ctx.LogDebugf("[Database] Enqueuing save request")
-
+func (j *JsonDatabase) Save1(ctx basecontext.ApiContext) error {
 	defer func() {
 		if r := recover(); r != nil {
 			ctx.LogErrorf("[Database] Panic occurred during save: %v", r)
 		}
 	}()
 
-	wg.Add(1)
-	go j.ProcessSaveQueue(ctx)
-	wg.Wait()
-	ctx.LogDebugf("[Database] Save request completed")
+	go func() {
+		// recover from panic
+		defer func() {
+			if r := recover(); r != nil {
+				ctx.LogErrorf("[Database] Panic occurred during save: %v", r)
+			}
+		}()
+
+		for {
+			select {
+			case <-j.cancel:
+				return
+			default:
+				ctx.LogDebugf("[Database] Enqueuing next save request")
+				time.Sleep(j.Config.SaveInterval)
+				wg.Add(1)
+				go j.ProcessSaveQueue(ctx)
+				wg.Wait()
+				ctx.LogDebugf("[Database] Save request completed")
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (j *JsonDatabase) SaveNow(ctx basecontext.ApiContext) error {
+	ctx.LogDebugf("[Database] Received for save request")
+	mutexLock.Lock()
+	if err := j.processSave(ctx); err != nil {
+		ctx.LogErrorf("[Database] Error saving database: %v", err)
+		return err
+	}
+
+	mutexLock.Unlock()
 	return nil
 }
 
@@ -243,62 +288,14 @@ func (j *JsonDatabase) ProcessSaveQueue(ctx basecontext.ApiContext) {
 	mutexLock.Unlock()
 }
 
-// func (j *JsonDatabase) ProcessSaveQueue(ctx basecontext.ApiContext) {
-// 	defer func() {
-// 		if r := recover(); r != nil {
-// 			ctx.LogErrorf("[Database] Panic occurred during save: %v", r)
-// 			ctx.LogDebugf("[Database] Saved %v requests", totalSaveRequests)
-// 			ctx.LogDebugf("[Database] SyncGroup count %v requests", syncGroupCount)
-// 		}
-// 	}()
-
-// 	for {
-// 		ctx.LogDebugf("[Database] Waiting for save request")
-// 		<-j.saveProcess
-// 		ctx.LogDebugf("[Database] Received for save request")
-// 	innerLoop:
-// 		for {
-// 			if len(j.saveQueue) == 0 {
-// 				ctx.LogDebugf("[Database] No save requests in queue")
-// 				break innerLoop
-// 			}
-// 			j.saveQueue = j.saveQueue[1:]
-// 			mutexLock.Lock()
-// 			if err := j.processSave(ctx); err != nil {
-// 				ctx.LogErrorf("[Database] Error saving database: %v", err)
-// 				syncGroupCount--
-// 				if syncGroupCount < 0 {
-// 					fmt.Printf("here it is")
-// 				}
-// 				wg.Done()
-// 				break innerLoop
-// 			}
-// 			mutexLock.Unlock()
-
-// 			syncGroupCount--
-// 			ctx.LogDebugf("[Database] SyncGroup count %v requests", syncGroupCount)
-// 			if syncGroupCount < 0 {
-// 				fmt.Printf("here it is")
-// 				break innerLoop
-// 			}
-
-// 			mutexLock.Lock()
-// 			wg.Done()
-// 			mutexLock.Unlock()
-// 		}
-// 	}
-// }
-
 func (j *JsonDatabase) processSave(ctx basecontext.ApiContext) error {
 	j.saveMutex.Lock()
 
 	cfg := config.Get()
-	// Backup the file before attempting to read it
-	backupFilename := j.filename + ".save.bak"
-	err := helper.CopyFile(j.filename, backupFilename)
-	if err != nil {
+	// Lets first backup the file
+	if err := j.Backup(ctx); err != nil {
+		ctx.LogErrorf("[Database] Error managing backup files: %v", err)
 		j.saveMutex.Unlock()
-		ctx.LogErrorf("[Database] Error creating backup file: %v", err)
 		return err
 	}
 
@@ -374,4 +371,21 @@ func (j *JsonDatabase) processSave(ctx basecontext.ApiContext) error {
 	j.isSaving = false
 	j.saveMutex.Unlock()
 	return nil
+}
+
+func LockRecord(ctx basecontext.ApiContext, dbRecord *models.DbRecord) {
+	mutexLock.Lock()
+	if dbRecord == nil {
+		dbRecord = &models.DbRecord{}
+	}
+	dbRecord.IsLocked = true
+	dbRecord.LockedAt = helpers.GetUtcCurrentDateTime()
+	dbRecord.LockedBy = ctx.GetUser().Email
+	mutexLock.Unlock()
+}
+
+func UnlockRecord(ctx basecontext.ApiContext, dbRecord *models.DbRecord) {
+	mutexLock.Lock()
+	dbRecord.IsLocked = false
+	mutexLock.Unlock()
 }

--- a/src/data/models/api_key.go
+++ b/src/data/models/api_key.go
@@ -9,4 +9,5 @@ type ApiKey struct {
 	CreatedAt string `json:"created_at"`
 	UpdatedAt string `json:"updated_at"`
 	RevokedAt string `json:"revoked_at"`
+	*DbRecord `json:"db_record"`
 }

--- a/src/data/models/db_common.go
+++ b/src/data/models/db_common.go
@@ -1,0 +1,7 @@
+package models
+
+type DbRecord struct {
+	IsLocked bool   `json:"is_locked"`
+	LockedBy string `json:"locked_by"`
+	LockedAt string `json:"locked_at"`
+}

--- a/src/data/models/virtual_machines.go
+++ b/src/data/models/virtual_machines.go
@@ -1,0 +1,261 @@
+package models
+
+type ParallelsVM struct {
+	Host                  string                 `json:"host,omitempty"`
+	HostId                string                 `json:"host_id,omitempty"`
+	HostState             string                 `json:"host_state,omitempty"`
+	User                  string                 `json:"user"`
+	ID                    string                 `json:"ID"`
+	Name                  string                 `json:"Name"`
+	Description           string                 `json:"Description"`
+	Type                  string                 `json:"Type"`
+	State                 string                 `json:"State"`
+	OS                    string                 `json:"OS"`
+	Template              string                 `json:"Template"`
+	Uptime                string                 `json:"Uptime"`
+	HomePath              string                 `json:"Home path"`
+	Home                  string                 `json:"Home"`
+	RestoreImage          string                 `json:"Restore Image"`
+	GuestTools            GuestTools             `json:"GuestTools"`
+	MouseAndKeyboard      MouseAndKeyboard       `json:"Mouse and Keyboard"`
+	USBAndBluetooth       USBAndBluetooth        `json:"USB and Bluetooth"`
+	StartupAndShutdown    StartupAndShutdown     `json:"Startup and Shutdown"`
+	Optimization          Optimization           `json:"Optimization"`
+	TravelMode            TravelMode             `json:"Travel mode"`
+	Security              Security               `json:"Security"`
+	SmartGuard            Expiration             `json:"Smart Guard"`
+	Modality              Modality               `json:"Modality"`
+	Fullscreen            Fullscreen             `json:"Fullscreen"`
+	Coherence             Coherence              `json:"Coherence"`
+	TimeSynchronization   TimeSynchronization    `json:"Time Synchronization"`
+	Expiration            Expiration             `json:"Expiration"`
+	BootOrder             string                 `json:"Boot order"`
+	BIOSType              string                 `json:"BIOS type"`
+	EFISecureBoot         string                 `json:"EFI Secure boot"`
+	AllowSelectBootDevice string                 `json:"Allow select boot device"`
+	ExternalBootDevice    string                 `json:"External boot device"`
+	SMBIOSSettings        SMBIOSSettings         `json:"SMBIOS settings"`
+	Hardware              Hardware               `json:"Hardware"`
+	HostSharedFolders     map[string]interface{} `json:"Host Shared Folders"`
+	HostDefinedSharing    string                 `json:"Host defined sharing"`
+	SharedProfile         Expiration             `json:"Shared Profile"`
+	SharedApplications    SharedApplications     `json:"Shared Applications"`
+	SmartMount            SmartMount             `json:"SmartMount"`
+	MiscellaneousSharing  MiscellaneousSharing   `json:"Miscellaneous Sharing"`
+	Advanced              Advanced               `json:"Advanced"`
+	PrintManagement       PrintManagement        `json:"Print Management,omitempty"`
+	GuestSharedFolders    GuestSharedFolders     `json:"Guest Shared Folders,omitempty"`
+}
+
+type Advanced struct {
+	VMHostnameSynchronization    string `json:"VM hostname synchronization"`
+	PublicSSHKeysSynchronization string `json:"Public SSH keys synchronization"`
+	ShowDeveloperTools           string `json:"Show developer tools"`
+	SwipeFromEdges               string `json:"Swipe from edges"`
+	ShareHostLocation            string `json:"Share host location"`
+	RosettaLinux                 string `json:"Rosetta Linux"`
+}
+
+type Coherence struct {
+	ShowWindowsSystrayInMACMenu string `json:"Show Windows systray in Mac menu"`
+	AutoSwitchToFullScreen      string `json:"Auto-switch to full screen"`
+	DisableAero                 string `json:"Disable aero"`
+	HideMinimizedWindows        string `json:"Hide minimized windows"`
+}
+
+type Expiration struct {
+	Enabled bool `json:"enabled"`
+}
+
+type Fullscreen struct {
+	UseAllDisplays        string `json:"Use all displays"`
+	ActivateSpacesOnClick string `json:"Activate spaces on click"`
+	OptimizeForGames      string `json:"Optimize for games"`
+	GammaControl          string `json:"Gamma control"`
+	ScaleViewMode         string `json:"Scale view mode"`
+}
+
+type GuestSharedFolders struct {
+	Enabled   bool   `json:"enabled"`
+	Automount string `json:"Automount"`
+}
+
+type GuestTools struct {
+	State   string `json:"state"`
+	Version string `json:"version,omitempty"`
+}
+
+type Hardware struct {
+	CPU         CPU         `json:"cpu"`
+	Memory      Memory      `json:"memory"`
+	Video       Video       `json:"video"`
+	MemoryQuota MemoryQuota `json:"memory_quota"`
+	Hdd0        Hdd0        `json:"hdd0"`
+	Cdrom0      Cdrom0      `json:"cdrom0"`
+	USB         Expiration  `json:"usb"`
+	Net0        Net0        `json:"net0"`
+	Sound0      Sound0      `json:"sound0"`
+}
+
+type CPU struct {
+	Cpus    int64  `json:"cpus"`
+	Auto    string `json:"auto"`
+	VTX     bool   `json:"VT-x"`
+	Hotplug bool   `json:"hotplug"`
+	Accl    string `json:"accl"`
+	Mode    string `json:"mode"`
+	Type    string `json:"type"`
+}
+
+type Cdrom0 struct {
+	Enabled bool   `json:"enabled"`
+	Port    string `json:"port"`
+	Image   string `json:"image"`
+	State   string `json:"state,omitempty"`
+}
+
+type Hdd0 struct {
+	Enabled       bool   `json:"enabled"`
+	Port          string `json:"port"`
+	Image         string `json:"image"`
+	Type          string `json:"type"`
+	Size          string `json:"size"`
+	OnlineCompact string `json:"online-compact"`
+}
+
+type Memory struct {
+	Size    string `json:"size"`
+	Auto    string `json:"auto"`
+	Hotplug bool   `json:"hotplug"`
+}
+
+type MemoryQuota struct {
+	Auto string `json:"auto"`
+}
+
+type Net0 struct {
+	Enabled bool   `json:"enabled"`
+	Type    string `json:"type"`
+	MAC     string `json:"mac"`
+	Card    string `json:"card"`
+}
+
+type Sound0 struct {
+	Enabled bool   `json:"enabled"`
+	Output  string `json:"output"`
+	Mixer   string `json:"mixer"`
+}
+
+type Video struct {
+	AdapterType           string `json:"adapter-type"`
+	Size                  string `json:"size"`
+	The3DAcceleration     string `json:"3d-acceleration"`
+	VerticalSync          string `json:"vertical-sync"`
+	HighResolution        string `json:"high-resolution"`
+	HighResolutionInGuest string `json:"high-resolution-in-guest"`
+	NativeScalingInGuest  string `json:"native-scaling-in-guest"`
+	AutomaticVideoMemory  string `json:"automatic-video-memory"`
+}
+
+type MiscellaneousSharing struct {
+	SharedClipboard string `json:"Shared clipboard"`
+	SharedCloud     string `json:"Shared cloud"`
+}
+
+type Modality struct {
+	OpacityPercentage  int64  `json:"Opacity (percentage)"`
+	StayOnTop          string `json:"Stay on top"`
+	ShowOnAllSpaces    string `json:"Show on all spaces "`
+	CaptureMouseClicks string `json:"Capture mouse clicks"`
+}
+
+type MouseAndKeyboard struct {
+	SmartMouseOptimizedForGames string `json:"Smart mouse optimized for games"`
+	StickyMouse                 string `json:"Sticky mouse"`
+	SmoothScrolling             string `json:"Smooth scrolling"`
+	KeyboardOptimizationMode    string `json:"Keyboard optimization mode"`
+}
+
+type Optimization struct {
+	FasterVirtualMachine     string `json:"Faster virtual machine"`
+	HypervisorType           string `json:"Hypervisor type"`
+	AdaptiveHypervisor       string `json:"Adaptive hypervisor"`
+	DisabledWindowsLogo      string `json:"Disabled Windows logo"`
+	AutoCompressVirtualDisks string `json:"Auto compress virtual disks"`
+	NestedVirtualization     string `json:"Nested virtualization"`
+	PMUVirtualization        string `json:"PMU virtualization"`
+	LongerBatteryLife        string `json:"Longer battery life"`
+	ShowBatteryStatus        string `json:"Show battery status"`
+	ResourceQuota            string `json:"Resource quota"`
+}
+
+type PrintManagement struct {
+	SynchronizeWithHostPrinters string `json:"Synchronize with host printers"`
+	SynchronizeDefaultPrinter   string `json:"Synchronize default printer"`
+	ShowHostPrinterUI           string `json:"Show host printer UI"`
+}
+
+type SMBIOSSettings struct {
+	BIOSVersion        string `json:"BIOS Version"`
+	SystemSerialNumber string `json:"System serial number"`
+	BoardManufacturer  string `json:"Board Manufacturer"`
+}
+
+type Security struct {
+	Encrypted                string `json:"Encrypted"`
+	TPMEnabled               string `json:"TPM enabled"`
+	TPMType                  string `json:"TPM type"`
+	CustomPasswordProtection string `json:"Custom password protection"`
+	ConfigurationIsLocked    string `json:"Configuration is locked"`
+	Protected                string `json:"Protected"`
+	Archived                 string `json:"Archived"`
+	Packed                   string `json:"Packed"`
+}
+
+type SharedApplications struct {
+	Enabled                      bool   `json:"enabled"`
+	HostToGuestAppsSharing       string `json:"Host-to-guest apps sharing"`
+	GuestToHostAppsSharing       string `json:"Guest-to-host apps sharing"`
+	ShowGuestAppsFolderInDock    string `json:"Show guest apps folder in Dock"`
+	ShowGuestNotifications       string `json:"Show guest notifications"`
+	BounceDockIconWhenAppFlashes string `json:"Bounce dock icon when app flashes"`
+}
+
+type SmartMount struct {
+	Enabled         bool   `json:"enabled"`
+	RemovableDrives string `json:"Removable drives,omitempty"`
+	CDDVDDrives     string `json:"CD/DVD drives,omitempty"`
+	NetworkShares   string `json:"Network shares,omitempty"`
+}
+
+type StartupAndShutdown struct {
+	Autostart      string `json:"Autostart"`
+	AutostartDelay int64  `json:"Autostart delay"`
+	Autostop       string `json:"Autostop"`
+	StartupView    string `json:"Startup view"`
+	OnShutdown     string `json:"On shutdown"`
+	OnWindowClose  string `json:"On window close"`
+	PauseIdle      string `json:"Pause idle"`
+	UndoDisks      string `json:"Undo disks"`
+}
+
+type TimeSynchronization struct {
+	Enabled                         bool   `json:"enabled"`
+	SmartMode                       string `json:"Smart mode"`
+	IntervalInSeconds               int64  `json:"Interval (in seconds)"`
+	TimezoneSynchronizationDisabled string `json:"Timezone synchronization disabled"`
+}
+
+type TravelMode struct {
+	EnterCondition string `json:"Enter condition"`
+	EnterThreshold int64  `json:"Enter threshold"`
+	QuitCondition  string `json:"Quit condition"`
+}
+
+type USBAndBluetooth struct {
+	AutomaticSharingCameras    string `json:"Automatic sharing cameras"`
+	AutomaticSharingBluetooth  string `json:"Automatic sharing bluetooth"`
+	AutomaticSharingSmartCards string `json:"Automatic sharing smart cards"`
+	AutomaticSharingGamepads   string `json:"Automatic sharing gamepads"`
+	SupportUSB30               string `json:"Support USB 3.0"`
+}

--- a/src/data/orchestrator.go
+++ b/src/data/orchestrator.go
@@ -113,9 +113,6 @@ func (j *JsonDatabase) CreateOrchestratorHost(ctx basecontext.ApiContext, host m
 	}
 
 	j.data.OrchestratorHosts = append(j.data.OrchestratorHosts, host)
-	if err := j.Save(ctx); err != nil {
-		return nil, err
-	}
 
 	return &host, nil
 }
@@ -133,9 +130,6 @@ func (j *JsonDatabase) DeleteOrchestratorHost(ctx basecontext.ApiContext, idOrHo
 		if strings.EqualFold(host.ID, idOrHost) || strings.EqualFold(host.Host, idOrHost) {
 			j.data.OrchestratorHosts = append(j.data.OrchestratorHosts[:i], j.data.OrchestratorHosts[i+1:]...)
 
-			if err := j.Save(ctx); err != nil {
-				return err
-			}
 			return nil
 		}
 	}
@@ -158,10 +152,6 @@ func (j *JsonDatabase) DeleteOrchestratorVirtualMachine(ctx basecontext.ApiConte
 				if strings.EqualFold(vm.ID, vmIdOrName) || strings.EqualFold(vm.Name, vmIdOrName) {
 					host.VirtualMachines = append(host.VirtualMachines[:j], host.VirtualMachines[j+1:]...)
 				}
-			}
-
-			if err := j.Save(ctx); err != nil {
-				return err
 			}
 
 			return nil
@@ -206,10 +196,6 @@ func (j *JsonDatabase) UpdateOrchestratorHost(ctx basecontext.ApiContext, host *
 				j.data.OrchestratorHosts[index].LastUnhealthyErrorMessage = host.LastUnhealthyErrorMessage
 				j.data.OrchestratorHosts[index].HealthCheck = host.HealthCheck
 				j.data.OrchestratorHosts[index].VirtualMachines = host.VirtualMachines
-
-				if err := j.Save(ctx); err != nil {
-					return nil, err
-				}
 
 				return &j.data.OrchestratorHosts[index], nil
 			} else {

--- a/src/data/packer_template.go
+++ b/src/data/packer_template.go
@@ -83,9 +83,6 @@ func (j *JsonDatabase) AddPackerTemplate(ctx basecontext.ApiContext, template *m
 
 	j.data.PackerTemplates = append(j.data.PackerTemplates, *template)
 
-	if err := j.Save(ctx); err != nil {
-		return nil, err
-	}
 	return template, nil
 }
 
@@ -105,9 +102,7 @@ func (j *JsonDatabase) DeletePackerTemplate(ctx basecontext.ApiContext, nameOrId
 			}
 
 			j.data.PackerTemplates = append(j.data.PackerTemplates[:i], j.data.PackerTemplates[i+1:]...)
-			if err := j.Save(ctx); err != nil {
-				return err
-			}
+
 			return nil
 		}
 	}
@@ -126,9 +121,7 @@ func (j *JsonDatabase) UpdatePackerTemplate(ctx basecontext.ApiContext, template
 				return nil, ErrUpdatingInternalPackerTemplate
 			}
 			j.data.PackerTemplates[i] = *template
-			if err := j.Save(ctx); err != nil {
-				return nil, err
-			}
+
 			return template, nil
 		}
 	}

--- a/src/data/roles.go
+++ b/src/data/roles.go
@@ -71,9 +71,7 @@ func (j *JsonDatabase) CreateRole(ctx basecontext.ApiContext, role models.Role) 
 	}
 
 	j.data.Roles = append(j.data.Roles, role)
-	if err := j.Save(ctx); err != nil {
-		return nil, err
-	}
+
 	return &role, nil
 }
 
@@ -92,9 +90,6 @@ func (j *JsonDatabase) DeleteRole(ctx basecontext.ApiContext, idOrName string) e
 				return ErrRemoveInternalRole
 			}
 			j.data.Roles = append(j.data.Roles[:i], j.data.Roles[i+1:]...)
-			if err := j.Save(ctx); err != nil {
-				return err
-			}
 			return nil
 		}
 	}
@@ -118,9 +113,6 @@ func (j *JsonDatabase) UpdateRole(ctx basecontext.ApiContext, role *models.Role)
 			}
 
 			j.data.Roles[i] = *role
-			if err := j.Save(ctx); err != nil {
-				return nil, err
-			}
 
 			return role, nil
 		}

--- a/src/data/schema.go
+++ b/src/data/schema.go
@@ -18,7 +18,6 @@ func (j *JsonDatabase) UpdateSchemaVersion(ctx basecontext.ApiContext, version s
 	}
 
 	j.data.Schema.Version = version
-	j.Save(ctx)
 
 	return nil
 }

--- a/src/data/users.go
+++ b/src/data/users.go
@@ -138,9 +138,6 @@ func (j *JsonDatabase) CreateUser(ctx basecontext.ApiContext, user models.User) 
 	user.UpdatedAt = helpers.GetUtcCurrentDateTime()
 	user.CreatedAt = helpers.GetUtcCurrentDateTime()
 	j.data.Users = append(j.data.Users, user)
-	if err := j.Save(ctx); err != nil {
-		return nil, err
-	}
 
 	return &user, nil
 }
@@ -172,9 +169,7 @@ func (j *JsonDatabase) UpdateUser(ctx basecontext.ApiContext, key models.User) e
 			}
 
 			j.data.Users[i].UpdatedAt = helpers.GetUtcCurrentDateTime()
-			if err := j.Save(ctx); err != nil {
-				return err
-			}
+
 			return nil
 		}
 	}
@@ -194,9 +189,7 @@ func (j *JsonDatabase) UpdateUserBlockStatus(ctx basecontext.ApiContext, key mod
 			j.data.Users[i].BlockedReason = key.BlockedReason
 			j.data.Users[i].FailedLoginAttempts = key.FailedLoginAttempts
 			j.data.Users[i].UpdatedAt = helpers.GetUtcCurrentDateTime()
-			if err := j.Save(ctx); err != nil {
-				return err
-			}
+
 			return nil
 		}
 	}
@@ -218,9 +211,7 @@ func (j *JsonDatabase) UpdateRootPassword(ctx basecontext.ApiContext, newPasswor
 			}
 			j.data.Users[i].Password = hashedPassword
 			j.data.Users[i].UpdatedAt = helpers.GetUtcCurrentDateTime()
-			if err := j.Save(ctx); err != nil {
-				return err
-			}
+
 			return nil
 		}
 	}
@@ -244,9 +235,7 @@ func (j *JsonDatabase) DeleteUser(ctx basecontext.ApiContext, id string) error {
 			}
 
 			j.data.Users = append(j.data.Users[:i], j.data.Users[i+1:]...)
-			if err := j.Save(ctx); err != nil {
-				return err
-			}
+
 			return nil
 		}
 	}
@@ -286,9 +275,7 @@ func (j *JsonDatabase) AddRoleToUser(ctx basecontext.ApiContext, userId string, 
 	for i, c := range j.data.Users {
 		if c.ID == userId {
 			j.data.Users[i].Roles = append(j.data.Users[i].Roles, *role)
-			if err := j.Save(ctx); err != nil {
-				return err
-			}
+
 			return nil
 		}
 	}
@@ -324,9 +311,7 @@ func (j *JsonDatabase) RemoveRoleFromUser(ctx basecontext.ApiContext, userId str
 			for e, r := range user.Roles {
 				if r.ID == role.ID {
 					j.data.Users[i].Roles = append(j.data.Users[i].Roles[:e], j.data.Users[i].Roles[e+1:]...)
-					if err := j.Save(ctx); err != nil {
-						return err
-					}
+
 					return nil
 				}
 			}
@@ -368,9 +353,7 @@ func (j *JsonDatabase) AddClaimToUser(ctx basecontext.ApiContext, userId string,
 	for i, c := range j.data.Users {
 		if c.ID == userId {
 			j.data.Users[i].Claims = append(j.data.Users[i].Claims, *claim)
-			if err := j.Save(ctx); err != nil {
-				return err
-			}
+
 			return nil
 		}
 	}
@@ -406,9 +389,7 @@ func (j *JsonDatabase) RemoveClaimFromUser(ctx basecontext.ApiContext, userId st
 			for e, r := range user.Claims {
 				if r.ID == claim.ID {
 					j.data.Users[i].Claims = append(j.data.Users[i].Claims[:e], j.data.Users[i].Claims[e+1:]...)
-					if err := j.Save(ctx); err != nil {
-						return err
-					}
+
 					return nil
 				}
 			}

--- a/src/helpers/os.go
+++ b/src/helpers/os.go
@@ -43,8 +43,8 @@ func CreateDirIfNotExist(path string) error {
 	return nil
 }
 
-func ExecuteWithNoOutput(command Command) (string, error) {
-	cmd := exec.Command(command.Command, command.Args...) // #nosec G204 This is not a user input, it is a helper function
+func ExecuteWithNoOutput(ctx context.Context, command Command) (string, error) {
+	cmd := exec.CommandContext(ctx, command.Command, command.Args...) // #nosec G204 This is not a user input, it is a helper function
 	if command.WorkingDirectory != "" {
 		cmd.Dir = command.WorkingDirectory
 	}
@@ -66,8 +66,8 @@ func ExecuteWithNoOutput(command Command) (string, error) {
 	return stdOut.String(), nil
 }
 
-func ExecuteWithOutput(command Command) (stdout string, stderr string, exitCode int, err error) {
-	cmd := exec.Command(command.Command, command.Args...) // #nosec G204 This is not a user input, it is a helper function
+func ExecuteWithOutput(ctx context.Context, command Command) (stdout string, stderr string, exitCode int, err error) {
+	cmd := exec.CommandContext(ctx, command.Command, command.Args...) // #nosec G204 This is not a user input, it is a helper function
 	if command.WorkingDirectory != "" {
 		cmd.Dir = command.WorkingDirectory
 	}
@@ -339,7 +339,7 @@ func CopyDir(src string, dst string) (err error) {
 			Args:    []string{"-c", "-r", src, dst},
 		}
 
-		ExecuteWithNoOutput(cmd)
+		ExecuteWithNoOutput(context.TODO(), cmd)
 		return
 	}
 
@@ -413,7 +413,7 @@ func CopyFile(src, dst string) (err error) {
 			Args:    []string{"-c", src, dst},
 		}
 
-		ExecuteWithNoOutput(cmd)
+		ExecuteWithNoOutput(context.Background(), cmd)
 		return
 	}
 

--- a/src/helpers/os.go
+++ b/src/helpers/os.go
@@ -44,6 +44,9 @@ func CreateDirIfNotExist(path string) error {
 }
 
 func ExecuteWithNoOutput(ctx context.Context, command Command) (string, error) {
+	if ctx == nil {
+		ctx = context.TODO()
+	}
 	cmd := exec.CommandContext(ctx, command.Command, command.Args...) // #nosec G204 This is not a user input, it is a helper function
 	if command.WorkingDirectory != "" {
 		cmd.Dir = command.WorkingDirectory

--- a/src/helpers/os.go
+++ b/src/helpers/os.go
@@ -342,7 +342,9 @@ func CopyDir(src string, dst string) (err error) {
 			Args:    []string{"-c", "-r", src, dst},
 		}
 
-		ExecuteWithNoOutput(context.TODO(), cmd)
+		if _, err = ExecuteWithNoOutput(context.TODO(), cmd); err != nil {
+			return err
+		}
 		return
 	}
 
@@ -416,7 +418,10 @@ func CopyFile(src, dst string) (err error) {
 			Args:    []string{"-c", src, dst},
 		}
 
-		ExecuteWithNoOutput(context.Background(), cmd)
+		if _, err := ExecuteWithNoOutput(context.Background(), cmd); err != nil {
+			return err
+		}
+
 		return
 	}
 

--- a/src/install/main.go
+++ b/src/install/main.go
@@ -108,13 +108,13 @@ func installServiceOnMac(ctx basecontext.ApiContext, config ApiServiceConfig) er
 		Args:    []string{"launchctl", "load", daemonPath},
 	}
 
-	if _, err := helpers.ExecuteWithNoOutput(chownCmd); err != nil {
+	if _, err := helpers.ExecuteWithNoOutput(ctx.Context(), chownCmd); err != nil {
 		return err
 	}
-	if _, err := helpers.ExecuteWithNoOutput(chmod); err != nil {
+	if _, err := helpers.ExecuteWithNoOutput(ctx.Context(), chmod); err != nil {
 		return err
 	}
-	if _, err := helpers.ExecuteWithNoOutput(launchdLoadCmd); err != nil {
+	if _, err := helpers.ExecuteWithNoOutput(ctx.Context(), launchdLoadCmd); err != nil {
 		return err
 	}
 
@@ -131,7 +131,7 @@ func uninstallServiceOnMac(ctx basecontext.ApiContext, removeDatabase bool) erro
 		Args:    []string{"launchctl", "unload", daemonPath},
 	}
 
-	if _, err := helpers.ExecuteWithNoOutput(cmd); err != nil {
+	if _, err := helpers.ExecuteWithNoOutput(ctx.Context(), cmd); err != nil {
 		return err
 	}
 

--- a/src/main.go
+++ b/src/main.go
@@ -53,8 +53,8 @@ func main() {
 				db := sp.JsonDatabase
 				if db != nil {
 					ctx := basecontext.NewRootBaseContext()
-					db.SaveNow(ctx)
-					db.SaveAs(ctx, fmt.Sprintf("data.panic.%s.json", strings.ReplaceAll(time.Now().Format("2006-01-02-15-04-05"), "-", "_")))
+					_ = db.SaveNow(ctx)
+					_ = db.SaveAs(ctx, fmt.Sprintf("data.panic.%s.json", strings.ReplaceAll(time.Now().Format("2006-01-02-15-04-05"), "-", "_")))
 				}
 			}
 			fmt.Fprintf(os.Stderr, "Exception: %v\n", err)
@@ -91,7 +91,9 @@ func cleanup() {
 		if db != nil {
 			ctx := basecontext.NewRootBaseContext()
 			ctx.LogInfof("[Core] Saving database")
-			db.SaveNow(ctx)
+			if err := db.SaveNow(ctx); err != nil {
+				ctx.LogErrorf("[Core] Error saving database: %v", err)
+			}
 		}
 	}
 }

--- a/src/orchestrator/common.go
+++ b/src/orchestrator/common.go
@@ -11,6 +11,8 @@ const (
 
 func (s *OrchestratorService) getApiClient(request models.OrchestratorHost) *apiclient.HttpClientService {
 	apiClient := apiclient.NewHttpClient(s.ctx)
+	apiClient.WithHeader("X-SOURCE", "ORCHESTRATOR_REQUEST")
+
 	if request.Authentication != nil {
 		if request.Authentication.ApiKey != "" {
 			apiClient.AuthorizeWithApiKey(request.Authentication.ApiKey)

--- a/src/orchestrator/get_orchestrator_resources.go
+++ b/src/orchestrator/get_orchestrator_resources.go
@@ -12,8 +12,6 @@ func (s *OrchestratorService) GetResources(ctx basecontext.ApiContext) ([]models
 		return nil, err
 	}
 
-	s.Refresh()
-
 	totalResources := dbService.GetOrchestratorTotalResources(ctx)
 	inUseResources := dbService.GetOrchestratorInUseResources(ctx)
 	availableResources := dbService.GetOrchestratorAvailableResources(ctx)

--- a/src/orchestrator/get_virtual_machines.go
+++ b/src/orchestrator/get_virtual_machines.go
@@ -16,8 +16,6 @@ func (s *OrchestratorService) GetVirtualMachines(ctx basecontext.ApiContext, fil
 		return nil, err
 	}
 
-	s.Refresh()
-
 	hosts, err := dbService.GetOrchestratorHosts(ctx, "")
 	if err != nil {
 		return nil, err
@@ -47,8 +45,6 @@ func (s *OrchestratorService) GetVirtualMachines(ctx basecontext.ApiContext, fil
 }
 
 func (s *OrchestratorService) GetVirtualMachine(ctx basecontext.ApiContext, idOrName string) (*models.VirtualMachine, error) {
-	s.Refresh()
-
 	retryCount := 0
 	var resultVm *models.VirtualMachine
 
@@ -73,8 +69,6 @@ func (s *OrchestratorService) GetVirtualMachine(ctx basecontext.ApiContext, idOr
 		if resultVm != nil || retryCount >= 10 {
 			break
 		}
-
-		s.Refresh()
 
 		retryCount++
 		time.Sleep(1 * time.Second)

--- a/src/restapi/common_middleware.go
+++ b/src/restapi/common_middleware.go
@@ -45,9 +45,9 @@ func LoggerMiddlewareAdapter(logHealthCheck bool) Adapter {
 			if shouldLog {
 				id := GetRequestId(r)
 				common.Logger.Info("[%s] [%v] %v from %v", id, r.Method, r.URL.Path, r.Host)
-				rMatch := regexp.MustCompile("orchestrator/")
 				rMatchLogin := regexp.MustCompile("auth/token")
-				if !rMatch.MatchString(r.URL.Path) && !rMatchLogin.MatchString(r.URL.Path) {
+
+				if !isRequestFromOrchestratorRefresh(r) && !rMatchLogin.MatchString(r.URL.Path) {
 					ctx := basecontext.NewRootBaseContext()
 					properties := make(map[string]interface{})
 					properties["method"] = r.Method
@@ -59,4 +59,9 @@ func LoggerMiddlewareAdapter(logHealthCheck bool) Adapter {
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+func isRequestFromOrchestratorRefresh(r *http.Request) bool {
+	xSourceHeader := r.Header.Get("X-SOURCE")
+	return xSourceHeader == "ORCHESTRATOR_REQUEST"
 }

--- a/src/serviceprovider/brew/main.go
+++ b/src/serviceprovider/brew/main.go
@@ -9,8 +9,6 @@ import (
 	"github.com/Parallels/prl-devops-service/helpers"
 	"github.com/Parallels/prl-devops-service/serviceprovider/interfaces"
 	"github.com/Parallels/prl-devops-service/serviceprovider/system"
-
-	"github.com/cjlapao/common-go/commands"
 )
 
 var globalBrewService *BrewService
@@ -55,7 +53,11 @@ func (s *BrewService) Name() string {
 
 func (s *BrewService) FindPath() string {
 	s.ctx.LogInfof("Getting brew executable")
-	out, err := commands.ExecuteWithNoOutput("which", "brew")
+	cmd := helpers.Command{
+		Command: "which",
+		Args:    []string{"brew"},
+	}
+	out, err := helpers.ExecuteWithNoOutput(s.ctx.Context(), cmd)
 	path := strings.ReplaceAll(strings.TrimSpace(out), "\n", "")
 	if err != nil || path == "" {
 		s.ctx.LogWarnf("Brew executable not found, trying to find it in the default locations")
@@ -86,7 +88,7 @@ func (s *BrewService) Version() string {
 		Args:    []string{"--version"},
 	}
 
-	stdout, _, _, err := helpers.ExecuteWithOutput(cmd)
+	stdout, _, _, err := helpers.ExecuteWithOutput(s.ctx.Context(), cmd)
 	if err != nil {
 		return "unknown"
 	}
@@ -124,7 +126,7 @@ func (s *BrewService) Install(asUser, version string, flags map[string]string) e
 	}
 
 	s.ctx.LogInfof("Installing %s with command: %v", s.Name(), cmd.String())
-	_, err := helpers.ExecuteWithNoOutput(cmd)
+	_, err := helpers.ExecuteWithNoOutput(s.ctx.Context(), cmd)
 	if err != nil {
 		return err
 	}
@@ -142,7 +144,7 @@ func (s *BrewService) Uninstall(asUser string, uninstallDependencies bool) error
 			Args:    []string{"-c", "\"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh)\""},
 		}
 
-		_, err := helpers.ExecuteWithNoOutput(cmd)
+		_, err := helpers.ExecuteWithNoOutput(s.ctx.Context(), cmd)
 		if err != nil {
 			return err
 		}

--- a/src/serviceprovider/main.go
+++ b/src/serviceprovider/main.go
@@ -71,14 +71,13 @@ func InitCatalogServices(ctx basecontext.ApiContext) {
 		}
 
 		if cfg.DatabaseFolder() != "" {
-			globalProvider.JsonDatabase = data.NewJsonDatabase(filepath.Join(cfg.DatabaseFolder(), "/data.json"))
+			globalProvider.JsonDatabase = data.NewJsonDatabase(ctx, filepath.Join(cfg.DatabaseFolder(), "/data.json"))
 		} else {
-			globalProvider.JsonDatabase = data.NewJsonDatabase(filepath.Join(dbLocation, "/data.json"))
+			globalProvider.JsonDatabase = data.NewJsonDatabase(ctx, filepath.Join(dbLocation, "/data.json"))
 		}
 
 		_ = globalProvider.JsonDatabase.Connect(ctx)
 		ctx.LogInfof("Running as %s, using %s/data.json file", globalProvider.RunningUser, dbLocation)
-		_ = globalProvider.JsonDatabase.Save(ctx)
 	} else {
 		userHome, err := globalProvider.System.GetUserHome(ctx, currentUser)
 		if err != nil {
@@ -91,9 +90,9 @@ func InitCatalogServices(ctx basecontext.ApiContext) {
 		}
 
 		if cfg.DatabaseFolder() != "" {
-			globalProvider.JsonDatabase = data.NewJsonDatabase(filepath.Join(cfg.DatabaseFolder(), "/data.json"))
+			globalProvider.JsonDatabase = data.NewJsonDatabase(ctx, filepath.Join(cfg.DatabaseFolder(), "/data.json"))
 		} else {
-			globalProvider.JsonDatabase = data.NewJsonDatabase(filepath.Join(dbLocation, "/data.json"))
+			globalProvider.JsonDatabase = data.NewJsonDatabase(ctx, filepath.Join(dbLocation, "/data.json"))
 		}
 		_ = globalProvider.JsonDatabase.Connect(ctx)
 		ctx.LogInfof("Running as %s, using %s/data.json file", globalProvider.RunningUser, dbLocation)
@@ -157,14 +156,13 @@ func InitServices(ctx basecontext.ApiContext) {
 		}
 
 		if cfg.DatabaseFolder() != "" {
-			globalProvider.JsonDatabase = data.NewJsonDatabase(filepath.Join(cfg.DatabaseFolder(), "/data.json"))
+			globalProvider.JsonDatabase = data.NewJsonDatabase(ctx, filepath.Join(cfg.DatabaseFolder(), "/data.json"))
 		} else {
-			globalProvider.JsonDatabase = data.NewJsonDatabase(filepath.Join(dbLocation, "/data.json"))
+			globalProvider.JsonDatabase = data.NewJsonDatabase(ctx, filepath.Join(dbLocation, "/data.json"))
 		}
 
 		_ = globalProvider.JsonDatabase.Connect(ctx)
 		ctx.LogInfof("Running as %s, using %s/data.json file", globalProvider.RunningUser, dbLocation)
-		_ = globalProvider.JsonDatabase.Save(ctx)
 	} else {
 		userHome, err := globalProvider.System.GetUserHome(ctx, currentUser)
 		if err != nil {
@@ -177,9 +175,9 @@ func InitServices(ctx basecontext.ApiContext) {
 		}
 
 		if cfg.DatabaseFolder() != "" {
-			globalProvider.JsonDatabase = data.NewJsonDatabase(filepath.Join(cfg.DatabaseFolder(), "/data.json"))
+			globalProvider.JsonDatabase = data.NewJsonDatabase(ctx, filepath.Join(cfg.DatabaseFolder(), "/data.json"))
 		} else {
-			globalProvider.JsonDatabase = data.NewJsonDatabase(filepath.Join(dbLocation, "/data.json"))
+			globalProvider.JsonDatabase = data.NewJsonDatabase(ctx, filepath.Join(dbLocation, "/data.json"))
 		}
 
 		_ = globalProvider.JsonDatabase.Connect(ctx)

--- a/src/serviceprovider/packer/main.go
+++ b/src/serviceprovider/packer/main.go
@@ -8,8 +8,6 @@ import (
 	"github.com/Parallels/prl-devops-service/errors"
 	"github.com/Parallels/prl-devops-service/helpers"
 	"github.com/Parallels/prl-devops-service/serviceprovider/interfaces"
-
-	"github.com/cjlapao/common-go/commands"
 )
 
 var globalPackerService *PackerService
@@ -48,7 +46,11 @@ func (s *PackerService) Name() string {
 
 func (s *PackerService) FindPath() string {
 	s.ctx.LogInfof("Getting packer executable")
-	out, err := commands.ExecuteWithNoOutput("which", "packer")
+	cmd := helpers.Command{
+		Command: "which",
+		Args:    []string{"packer"},
+	}
+	out, err := helpers.ExecuteWithNoOutput(s.ctx.Context(), cmd)
 	path := strings.ReplaceAll(strings.TrimSpace(out), "\n", "")
 	if err != nil || path == "" {
 		s.ctx.LogWarnf("Packer executable not found, trying to find it in the default locations")
@@ -77,7 +79,7 @@ func (s *PackerService) Version() string {
 		Args:    []string{"--version"},
 	}
 
-	stdout, _, _, err := helpers.ExecuteWithOutput(cmd)
+	stdout, _, _, err := helpers.ExecuteWithOutput(s.ctx.Context(), cmd)
 	if err != nil {
 		return "unknown"
 	}
@@ -123,7 +125,7 @@ func (s *PackerService) Install(asUser, version string, flags map[string]string)
 	}
 
 	s.ctx.LogInfof("Installing %s with command: %v", s.Name(), cmd.String())
-	_, err := helpers.ExecuteWithNoOutput(cmd)
+	_, err := helpers.ExecuteWithNoOutput(s.ctx.Context(), cmd)
 	if err != nil {
 		return err
 	}
@@ -148,7 +150,7 @@ func (s *PackerService) Uninstall(asUser string, uninstallDependencies bool) err
 			}
 		}
 
-		_, err := helpers.ExecuteWithNoOutput(cmd)
+		_, err := helpers.ExecuteWithNoOutput(s.ctx.Context(), cmd)
 		if err != nil {
 			return err
 		}

--- a/src/serviceprovider/parallelsdesktop/license.go
+++ b/src/serviceprovider/parallelsdesktop/license.go
@@ -16,7 +16,7 @@ func (s *ParallelsService) GetLicense() (*models.ParallelsDesktopLicense, error)
 		Args:    []string{"info", "--license", "--json"},
 	}
 
-	output, _, _, err := helpers.ExecuteWithOutput(getLicenseCmd)
+	output, _, _, err := helpers.ExecuteWithOutput(s.ctx.Context(), getLicenseCmd)
 	if err != nil {
 		return nil, err
 	}
@@ -51,15 +51,15 @@ func (s *ParallelsService) InstallLicense(licenseKey, username, password string)
 			Command: s.serverExecutable,
 			Args:    []string{"web-portal", "signin", username, "--read-passwd", "~/parallels_password.txt"},
 		}
-		_, err := helpers.ExecuteWithNoOutput(passwordCmd)
+		_, err := helpers.ExecuteWithNoOutput(s.ctx.Context(), passwordCmd)
 		if err != nil {
 			return err
 		}
-		_, err = helpers.ExecuteWithNoOutput(signInCmd)
+		_, err = helpers.ExecuteWithNoOutput(s.ctx.Context(), signInCmd)
 		if err != nil {
 			return err
 		}
-		_, err = helpers.ExecuteWithNoOutput(installLicenseCmd)
+		_, err = helpers.ExecuteWithNoOutput(s.ctx.Context(), installLicenseCmd)
 		if err != nil {
 			return err
 		}
@@ -73,7 +73,7 @@ func (s *ParallelsService) InstallLicense(licenseKey, username, password string)
 
 		return nil
 	} else {
-		_, err := helpers.ExecuteWithNoOutput(installLicenseCmd)
+		_, err := helpers.ExecuteWithNoOutput(s.ctx.Context(), installLicenseCmd)
 		if err != nil {
 			return err
 		}
@@ -96,7 +96,7 @@ func (s *ParallelsService) DeactivateLicense() error {
 		Args:    []string{"deactivate-license", "--skip-network-errors"},
 	}
 
-	_, err := helpers.ExecuteWithNoOutput(deactivateLicenseCmd)
+	_, err := helpers.ExecuteWithNoOutput(s.ctx.Context(), deactivateLicenseCmd)
 	if err != nil {
 		return err
 	}

--- a/src/serviceprovider/parallelsdesktop/main.go
+++ b/src/serviceprovider/parallelsdesktop/main.go
@@ -1,6 +1,7 @@
 package parallelsdesktop
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -8,6 +9,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/Parallels/prl-devops-service/basecontext"
 	"github.com/Parallels/prl-devops-service/common"
@@ -24,7 +26,6 @@ import (
 	"github.com/Parallels/prl-devops-service/serviceprovider/system"
 	"github.com/google/uuid"
 
-	"github.com/cjlapao/common-go/commands"
 	"github.com/cjlapao/common-go/helper"
 )
 
@@ -72,7 +73,11 @@ func (s *ParallelsService) Name() string {
 
 func (s *ParallelsService) FindPath() string {
 	s.ctx.LogInfof("Getting prlctl executable")
-	out, err := commands.ExecuteWithNoOutput("which", "prlctl")
+	cmd := helpers.Command{
+		Command: "which",
+		Args:    []string{"prlctl"},
+	}
+	out, err := helpers.ExecuteWithNoOutput(s.ctx.Context(), cmd)
 	path := strings.ReplaceAll(strings.TrimSpace(out), "\n", "")
 	if err != nil || path == "" {
 		s.ctx.LogWarnf("Parallels Desktop CLI executable not found, trying to find it in the default locations")
@@ -112,7 +117,7 @@ func (s *ParallelsService) Version() string {
 		Args:    []string{"--version"},
 	}
 
-	stdout, _, _, err := helpers.ExecuteWithOutput(cmd)
+	stdout, _, _, err := helpers.ExecuteWithOutput(s.ctx.Context(), cmd)
 	if err != nil {
 		return "unknown"
 	}
@@ -163,7 +168,7 @@ func (s *ParallelsService) Install(asUser, version string, flags map[string]stri
 		}
 
 		s.ctx.LogInfof("Installing %s with command: %v", s.Name(), cmd.String())
-		_, err := helpers.ExecuteWithNoOutput(cmd)
+		_, err := helpers.ExecuteWithNoOutput(s.ctx.Context(), cmd)
 		if err != nil {
 			return err
 		}
@@ -216,7 +221,7 @@ func (s *ParallelsService) Uninstall(asUser string, uninstallDependencies bool) 
 			}
 		}
 
-		_, err := helpers.ExecuteWithNoOutput(cmd)
+		_, err := helpers.ExecuteWithNoOutput(s.ctx.Context(), cmd)
 		if err != nil {
 			return err
 		}
@@ -264,9 +269,50 @@ func (s *ParallelsService) IsLicensed() bool {
 	return s.isLicensed
 }
 
+func (s *ParallelsService) GetUserVm(ctx basecontext.ApiContext, username string) ([]models.ParallelsVM, error) {
+	ctx.LogInfof("Getting VMs for user: %s", username)
+
+	var userMachines []models.ParallelsVM
+	cmd := helpers.Command{
+		Command: "sudo",
+		Args:    []string{"-u", username, s.executable, "list", "-a", "-i", "--json"},
+	}
+	timeoutCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+
+	defer cancel()
+
+	stdout, err := helpers.ExecuteWithNoOutput(timeoutCtx, cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal([]byte(stdout), &userMachines)
+	if err != nil {
+		return nil, err
+	}
+
+	return userMachines, nil
+}
+
 func (s *ParallelsService) GetVms(ctx basecontext.ApiContext, filter string) ([]models.ParallelsVM, error) {
 	var systemMachines []models.ParallelsVM
 	users, err := system.Get().GetSystemUsers(ctx)
+	currentUser := "root"
+	if user, err := system.Get().GetCurrentUser(ctx); err == nil {
+		currentUser = user
+	}
+	if currentUser != "root" {
+		newAllUsers := make([]models.SystemUser, 0)
+		for _, user := range users {
+			if strings.EqualFold(user.Username, currentUser) {
+				newAllUsers = append(newAllUsers, user)
+				break
+			}
+		}
+
+		users = newAllUsers
+	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -276,16 +322,9 @@ func (s *ParallelsService) GetVms(ctx basecontext.ApiContext, filter string) ([]
 	}
 
 	for _, user := range users {
-		ctx.LogInfof("Getting VMs for user: %s", user.Username)
-		var userMachines []models.ParallelsVM
-		stdout, err := commands.ExecuteWithNoOutput("sudo", "-u", user.Username, s.executable, "list", "-a", "-i", "--json")
+		userMachines, err := s.GetUserVm(ctx, user.Username)
 		if err != nil {
-			continue
-		}
-
-		err = json.Unmarshal([]byte(stdout), &userMachines)
-		if err != nil {
-			continue
+			return nil, err
 		}
 
 		for _, machine := range userMachines {
@@ -387,7 +426,12 @@ func (s *ParallelsService) SetVmState(ctx basecontext.ApiContext, id string, des
 		return errors.New("Invalid desired state")
 	}
 
-	_, err = commands.ExecuteWithNoOutput("sudo", "-u", vm.User, s.executable, desiredState.String(), id)
+	cmd := helpers.Command{
+		Command: "sudo",
+		Args:    make([]string, 0),
+	}
+	cmd.Args = append(cmd.Args, "-u", vm.User, s.executable, desiredState.String(), id)
+	_, err = helpers.ExecuteWithNoOutput(s.ctx.Context(), cmd)
 	if err != nil {
 		return err
 	}
@@ -460,7 +504,13 @@ func (s *ParallelsService) DeleteVm(ctx basecontext.ApiContext, id string) error
 		return errors.New("VM is not stopped")
 	}
 
-	_, err = commands.ExecuteWithNoOutput("sudo", "-u", vm.User, s.executable, "delete", id)
+	cmd := helpers.Command{
+		Command: "sudo",
+		Args:    make([]string, 0),
+	}
+	cmd.Args = append(cmd.Args, "-u", vm.User, s.executable, "delete", id)
+
+	_, err = helpers.ExecuteWithNoOutput(s.ctx.Context(), cmd)
 	if err != nil {
 		return err
 	}
@@ -476,8 +526,13 @@ func (s *ParallelsService) VmStatus(ctx basecontext.ApiContext, id string) (*mod
 	if vm == nil {
 		return nil, errors.New("VM not found")
 	}
+	cmd := helpers.Command{
+		Command: "sudo",
+		Args:    make([]string, 0),
+	}
+	cmd.Args = append(cmd.Args, "-u", vm.User, s.executable, "list", id, "-a", "-f", "--json")
 
-	output, err := commands.ExecuteWithNoOutput("sudo", "-u", vm.User, s.executable, "list", id, "-a", "-f", "--json")
+	output, err := helpers.ExecuteWithNoOutput(s.ctx.Context(), cmd)
 	if err != nil {
 		return nil, err
 	}
@@ -547,7 +602,7 @@ func (s *ParallelsService) RegisterVm(ctx basecontext.ApiContext, r models.Regis
 	}
 
 	ctx.LogDebugf("Executing command: %s", cmd.String())
-	_, err := helpers.ExecuteWithNoOutput(cmd)
+	_, err := helpers.ExecuteWithNoOutput(s.ctx.Context(), cmd)
 	if err != nil {
 		return err
 	}
@@ -580,7 +635,7 @@ func (s *ParallelsService) UnregisterVm(ctx basecontext.ApiContext, r models.Unr
 	}
 
 	ctx.LogInfof(cmd.String())
-	_, err = helpers.ExecuteWithNoOutput(cmd)
+	_, err = helpers.ExecuteWithNoOutput(s.ctx.Context(), cmd)
 	if err != nil {
 		return errors.NewFromErrorf(err, "Error unregistering VM %s", r.ID)
 	}
@@ -612,7 +667,7 @@ func (s *ParallelsService) RenameVm(ctx basecontext.ApiContext, r models.RenameV
 	}
 
 	ctx.LogInfof(cmd.String())
-	_, err = helpers.ExecuteWithNoOutput(cmd)
+	_, err = helpers.ExecuteWithNoOutput(s.ctx.Context(), cmd)
 	if err != nil {
 		return err
 	}
@@ -639,7 +694,7 @@ func (s *ParallelsService) PackVm(ctx basecontext.ApiContext, idOrName string) e
 	}
 
 	cmd.Args = append(cmd.Args, s.executable, "pack", vm.ID)
-	_, err = helpers.ExecuteWithNoOutput(cmd)
+	_, err = helpers.ExecuteWithNoOutput(s.ctx.Context(), cmd)
 
 	return err
 }
@@ -663,7 +718,7 @@ func (s *ParallelsService) UnpackVm(ctx basecontext.ApiContext, idOrName string)
 	}
 
 	cmd.Args = append(cmd.Args, s.executable, "unpack", vm.ID)
-	_, err = helpers.ExecuteWithNoOutput(cmd)
+	_, err = helpers.ExecuteWithNoOutput(s.ctx.Context(), cmd)
 
 	return err
 }
@@ -673,7 +728,7 @@ func (s *ParallelsService) GetInfo() (*models.ParallelsDesktopInfo, error) {
 		return s.Info, nil
 	}
 
-	stdout, err := helpers.ExecuteWithNoOutput(helpers.Command{
+	stdout, err := helpers.ExecuteWithNoOutput(s.ctx.Context(), helpers.Command{
 		Command: s.serverExecutable,
 		Args:    []string{"info", "--json"},
 	})
@@ -702,7 +757,7 @@ func (s *ParallelsService) GetUsers(ctx basecontext.ApiContext) ([]*models.Paral
 		return s.Users, nil
 	}
 
-	stdout, err := helpers.ExecuteWithNoOutput(helpers.Command{
+	stdout, err := helpers.ExecuteWithNoOutput(s.ctx.Context(), helpers.Command{
 		Command: s.serverExecutable,
 		Args:    []string{"user", "list", "--json"},
 	})
@@ -1008,7 +1063,13 @@ func (s *ParallelsService) CreatePackerTemplateVm(ctx basecontext.ApiContext, te
 	}
 
 	if template.Owner != "root" {
-		_, err = commands.ExecuteWithNoOutput("sudo", "chown", "-R", template.Owner, destinationFolder)
+		cmd := helpers.Command{
+			Command: "sudo",
+			Args:    make([]string, 0),
+		}
+		cmd.Args = append(cmd.Args, "chown", "-R", template.Owner, destinationFolder)
+
+		_, err = helpers.ExecuteWithNoOutput(s.ctx.Context(), cmd)
 		if err != nil {
 			ctx.LogErrorf("Error changing owner of folder %s to %s: %s", destinationFolder, template.Owner, err.Error())
 			if cleanError := helpers.RemoveFolder(repoPath); cleanError != nil {
@@ -1020,7 +1081,13 @@ func (s *ParallelsService) CreatePackerTemplateVm(ctx basecontext.ApiContext, te
 	}
 
 	ctx.LogInfof("Moved folder %s to %s", sourceFolder, destinationFolder)
-	_, err = commands.ExecuteWithNoOutput("sudo", "-u", template.Owner, s.executable, "register", destinationFolder)
+	cmd := helpers.Command{
+		Command: "sudo",
+		Args:    make([]string, 0),
+	}
+	cmd.Args = append(cmd.Args, "-u", template.Owner, s.executable, "register", destinationFolder)
+
+	_, err = helpers.ExecuteWithNoOutput(s.ctx.Context(), cmd)
 	if err != nil {
 		ctx.LogErrorf("Error registering VM %s: %s", destinationFolder, err.Error())
 		if cleanError := helpers.RemoveFolder(repoPath); cleanError != nil {
@@ -1101,7 +1168,7 @@ func (s *ParallelsService) SetVmMachineOperation(ctx basecontext.ApiContext, vm 
 	}
 
 	ctx.LogDebugf(cmd.String())
-	_, err := helpers.ExecuteWithNoOutput(cmd)
+	_, err := helpers.ExecuteWithNoOutput(s.ctx.Context(), cmd)
 	if err != nil {
 		return err
 	}
@@ -1143,7 +1210,7 @@ func (s *ParallelsService) SetVmBootOperation(ctx basecontext.ApiContext, vm *mo
 	}
 
 	ctx.LogInfof(cmd.String())
-	_, err := helpers.ExecuteWithNoOutput(cmd)
+	_, err := helpers.ExecuteWithNoOutput(s.ctx.Context(), cmd)
 	if err != nil {
 		return err
 	}
@@ -1175,7 +1242,7 @@ func (s *ParallelsService) SetVmSharedFolderOperation(ctx basecontext.ApiContext
 	}
 
 	ctx.LogInfof(cmd.String())
-	_, err := helpers.ExecuteWithNoOutput(cmd)
+	_, err := helpers.ExecuteWithNoOutput(s.ctx.Context(), cmd)
 	if err != nil {
 		return err
 	}
@@ -1232,7 +1299,7 @@ func (s *ParallelsService) SetVmDeviceOperation(ctx basecontext.ApiContext, vm *
 	}
 
 	ctx.LogInfof(cmd.String())
-	_, err := helpers.ExecuteWithNoOutput(cmd)
+	_, err := helpers.ExecuteWithNoOutput(s.ctx.Context(), cmd)
 	if err != nil {
 		return err
 	}
@@ -1244,11 +1311,14 @@ func (s *ParallelsService) SetVmCpu(ctx basecontext.ApiContext, vm *models.Paral
 	if vm.State != "stopped" {
 		return errors.New("VM is not stopped")
 	}
-	cmd := "sudo"
-	args := make([]string, 0)
+	cmd := helpers.Command{
+		Command: "sudo",
+		Args:    make([]string, 0),
+	}
+
 	// Setting the owner in the command
 	if op.Owner != "root" {
-		args = append(args, "-u", op.Owner)
+		cmd.Args = append(cmd.Args, "-u", op.Owner)
 	}
 	switch op.Operation {
 	case "set":
@@ -1258,17 +1328,17 @@ func (s *ParallelsService) SetVmCpu(ctx basecontext.ApiContext, vm *models.Paral
 				return err
 			}
 		}
-		args = append(args, s.executable, "set", vm.ID, "--cpus", op.Value)
+		cmd.Args = append(cmd.Args, s.executable, "set", vm.ID, "--cpus", op.Value)
 	case "set_type":
 		if op.Value != "x86" && op.Value != "arm" {
 			return errors.Newf("Invalid CPU type %s", op.Value)
 		}
-		args = append(args, s.executable, "set", vm.ID, "--cpu-type", op.Value)
+		cmd.Args = append(cmd.Args, s.executable, "set", vm.ID, "--cpu-type", op.Value)
 	default:
 		return errors.Newf("Invalid operation %s", op.Operation)
 	}
 
-	_, err := commands.ExecuteWithNoOutput(cmd, args...)
+	_, err := helpers.ExecuteWithNoOutput(s.ctx.Context(), cmd)
 	if err != nil {
 		return err
 	}
@@ -1280,11 +1350,14 @@ func (s *ParallelsService) SetVmMemory(ctx basecontext.ApiContext, vm *models.Pa
 	if vm.State != "stopped" {
 		return errors.New("VM is not stopped")
 	}
-	cmd := "sudo"
-	args := make([]string, 0)
+	cmd := helpers.Command{
+		Command: "sudo",
+		Args:    make([]string, 0),
+	}
+
 	// Setting the owner in the command
 	if op.Owner != "root" {
-		args = append(args, "-u", op.Owner)
+		cmd.Args = append(cmd.Args, "-u", op.Owner)
 	}
 
 	switch op.Operation {
@@ -1295,12 +1368,12 @@ func (s *ParallelsService) SetVmMemory(ctx basecontext.ApiContext, vm *models.Pa
 				return err
 			}
 		}
-		args = append(args, s.executable, "set", vm.ID, "--memsize", op.Value)
+		cmd.Args = append(cmd.Args, s.executable, "set", vm.ID, "--memsize", op.Value)
 	default:
 		return errors.Newf("Invalid operation %s", op.Operation)
 	}
 
-	_, err := commands.ExecuteWithNoOutput(cmd, args...)
+	_, err := helpers.ExecuteWithNoOutput(s.ctx.Context(), cmd)
 	if err != nil {
 		return err
 	}
@@ -1312,11 +1385,14 @@ func (s *ParallelsService) SetVmRosettaEmulation(ctx basecontext.ApiContext, vm 
 	if vm.State != "stopped" {
 		return errors.New("VM is not stopped")
 	}
-	cmd := "sudo"
-	args := make([]string, 0)
+	cmd := helpers.Command{
+		Command: "sudo",
+		Args:    make([]string, 0),
+	}
+
 	// Setting the owner in the command
 	if op.Owner != "root" {
-		args = append(args, "-u", op.Owner)
+		cmd.Args = append(cmd.Args, "-u", op.Owner)
 	}
 
 	switch op.Operation {
@@ -1326,16 +1402,16 @@ func (s *ParallelsService) SetVmRosettaEmulation(ctx basecontext.ApiContext, vm 
 		}
 
 		if op.Value == "on" || op.Value == "true" {
-			args = append(args, s.executable, "set", vm.ID, "--rosetta-linux", "on")
+			cmd.Args = append(cmd.Args, s.executable, "set", vm.ID, "--rosetta-linux", "on")
 		}
 		if op.Value == "off" || op.Value == "false" {
-			args = append(args, s.executable, "set", vm.ID, "--rosetta-linux", "off")
+			cmd.Args = append(cmd.Args, s.executable, "set", vm.ID, "--rosetta-linux", "off")
 		}
 	default:
 		return errors.Newf("Invalid operation %s", op.Operation)
 	}
 
-	_, err := commands.ExecuteWithNoOutput(cmd, args...)
+	_, err := helpers.ExecuteWithNoOutput(s.ctx.Context(), cmd)
 	if err != nil {
 		return err
 	}
@@ -1376,7 +1452,7 @@ func (s *ParallelsService) SetTimeSyncOperation(ctx basecontext.ApiContext, vm *
 	}
 
 	ctx.LogInfof(cmd.String())
-	_, err := helpers.ExecuteWithNoOutput(cmd)
+	_, err := helpers.ExecuteWithNoOutput(s.ctx.Context(), cmd)
 	if err != nil {
 		return err
 	}
@@ -1413,7 +1489,7 @@ func (s *ParallelsService) ExecuteCommandOnVm(ctx basecontext.ApiContext, id str
 	cmd.Args = args
 
 	ctx.LogInfof("Executing command %s %s", cmd.Command, strings.Join(cmd.Args, " "))
-	stdout, stderr, exitCode, cmdError := helpers.ExecuteWithOutput(cmd)
+	stdout, stderr, exitCode, cmdError := helpers.ExecuteWithOutput(s.ctx.Context(), cmd)
 	response.Stdout = stdout
 	response.Stderr = stderr
 	response.ExitCode = exitCode
@@ -1478,17 +1554,20 @@ func (s *ParallelsService) RunCustomCommand(ctx basecontext.ApiContext, vm *mode
 	if vm.State != "stopped" {
 		return errors.New("VM is not stopped")
 	}
-	cmd := "sudo"
-	args := make([]string, 0)
-	// Setting the owner in the command
-	if op.Owner != "root" {
-		args = append(args, "-u", op.Owner)
+	cmd := helpers.Command{
+		Command: "sudo",
+		Args:    make([]string, 0),
 	}
 
-	args = append(args, s.executable, op.Operation, vm.ID)
-	args = append(args, op.GetCmdArgs()...)
+	// Setting the owner in the command
+	if op.Owner != "root" {
+		cmd.Args = append(cmd.Args, "-u", op.Owner)
+	}
 
-	_, err := commands.ExecuteWithNoOutput(cmd, args...)
+	cmd.Args = append(cmd.Args, s.executable, op.Operation, vm.ID)
+	cmd.Args = append(cmd.Args, op.GetCmdArgs()...)
+
+	_, err := helpers.ExecuteWithNoOutput(s.ctx.Context(), cmd)
 	if err != nil {
 		return err
 	}

--- a/src/serviceprovider/system/main.go
+++ b/src/serviceprovider/system/main.go
@@ -11,8 +11,6 @@ import (
 	"github.com/Parallels/prl-devops-service/helpers"
 	"github.com/Parallels/prl-devops-service/models"
 	"github.com/Parallels/prl-devops-service/serviceprovider/interfaces"
-
-	"github.com/cjlapao/common-go/commands"
 )
 
 var globalSystemService *SystemService
@@ -94,7 +92,12 @@ func (s *SystemService) GetSystemUsers(ctx basecontext.ApiContext) ([]models.Sys
 func (s *SystemService) getMacSystemUsers(ctx basecontext.ApiContext) ([]models.SystemUser, error) {
 	result := make([]models.SystemUser, 0)
 
-	out, err := commands.ExecuteWithNoOutput("dscl", ".", "list", "/Users")
+	cmd := helpers.Command{
+		Command: "dscl",
+		Args:    []string{".", "list", "/Users"},
+	}
+
+	out, err := helpers.ExecuteWithNoOutput(ctx.Context(), cmd)
 	if err != nil {
 		return nil, err
 	}
@@ -143,10 +146,19 @@ func (s *SystemService) getMacSystemUsers(ctx basecontext.ApiContext) ([]models.
 func (s *SystemService) getLinuxSystemUsers(ctx basecontext.ApiContext) ([]models.SystemUser, error) {
 	result := make([]models.SystemUser, 0)
 
+	usersCmd := helpers.Command{
+		Command: "/bin/getent",
+		Args:    []string{"passwd"},
+	}
 	usersCmdOut := ""
-	out, err := commands.ExecuteWithNoOutput("/bin/getent", "passwd")
+
+	out, err := helpers.ExecuteWithNoOutput(ctx.Context(), usersCmd)
 	if err != nil {
-		out, err := commands.ExecuteWithNoOutput("cat", "/etc/passwd")
+		catCommand := helpers.Command{
+			Command: "cat",
+			Args:    []string{"/etc/passwd"},
+		}
+		out, err := helpers.ExecuteWithNoOutput(ctx.Context(), catCommand)
 		if err != nil {
 			return nil, err
 		} else {
@@ -214,7 +226,11 @@ func (s *SystemService) GetUserHome(ctx basecontext.ApiContext, user string) (st
 }
 
 func (s *SystemService) getUserHomeMac(ctx basecontext.ApiContext, user string) (string, error) {
-	out, err := commands.ExecuteWithNoOutput("dscl", ".", "read", "/Users/"+user, "NFSHomeDirectory")
+	cmd := helpers.Command{
+		Command: "dscl",
+		Args:    []string{".", "read", "/Users/" + user, "NFSHomeDirectory"},
+	}
+	out, err := helpers.ExecuteWithNoOutput(ctx.Context(), cmd)
 	if err != nil {
 		return "", err
 	}
@@ -224,9 +240,17 @@ func (s *SystemService) getUserHomeMac(ctx basecontext.ApiContext, user string) 
 
 func (s *SystemService) getUserHomeLinux(ctx basecontext.ApiContext, user string) (string, error) {
 	usersCmdOut := ""
-	out, err := commands.ExecuteWithNoOutput("/bin/getent", "passwd")
+	cmd := helpers.Command{
+		Command: "/bin/getent",
+		Args:    []string{"passwd"},
+	}
+	out, err := helpers.ExecuteWithNoOutput(ctx.Context(), cmd)
 	if err != nil {
-		out, err := commands.ExecuteWithNoOutput("cat", "/etc/passwd")
+		catCmd := helpers.Command{
+			Command: "cat",
+			Args:    []string{"/etc/passwd"},
+		}
+		out, err := helpers.ExecuteWithNoOutput(ctx.Context(), catCmd)
 		if err != nil {
 			return "", err
 		} else {
@@ -268,7 +292,11 @@ func (s *SystemService) GetUserId(ctx basecontext.ApiContext, user string) (int,
 }
 
 func (s *SystemService) getUserIdMac(ctx basecontext.ApiContext, user string) (int, error) {
-	out, err := commands.ExecuteWithNoOutput("dscl", ".", "read", "/Users/"+user, "UniqueID")
+	cmd := helpers.Command{
+		Command: "dscl",
+		Args:    []string{".", "read", "/Users/" + user, "UniqueID"},
+	}
+	out, err := helpers.ExecuteWithNoOutput(ctx.Context(), cmd)
 	if err != nil {
 		return -1, err
 	}
@@ -287,7 +315,11 @@ func (s *SystemService) getUserIdMac(ctx basecontext.ApiContext, user string) (i
 }
 
 func (s *SystemService) getUserIdLinux(ctx basecontext.ApiContext, user string) (int, error) {
-	out, err := commands.ExecuteWithNoOutput("/bin/id", "-u", user)
+	cmd := helpers.Command{
+		Command: "/bin/id",
+		Args:    []string{"-u", user},
+	}
+	out, err := helpers.ExecuteWithNoOutput(ctx.Context(), cmd)
 	if err != nil {
 		return -1, err
 	}
@@ -323,7 +355,10 @@ func (s *SystemService) GetCurrentUser(ctx basecontext.ApiContext) (string, erro
 }
 
 func (s *SystemService) getMacCurrentUser(ctx basecontext.ApiContext) (string, error) {
-	out, err := commands.ExecuteWithNoOutput("whoami")
+	cmd := helpers.Command{
+		Command: "whoami",
+	}
+	out, err := helpers.ExecuteWithNoOutput(ctx.Context(), cmd)
 	if err != nil {
 		return "", err
 	}
@@ -361,7 +396,11 @@ func (s *SystemService) GetUniqueId(ctx basecontext.ApiContext) (string, error) 
 }
 
 func (s *SystemService) getUniqueIdMac(ctx basecontext.ApiContext) (string, error) {
-	out, err := commands.ExecuteWithNoOutput("ioreg", "-rd1", "-c", "IOPlatformExpertDevice")
+	cmd := helpers.Command{
+		Command: "ioreg",
+		Args:    []string{"-rd1", "-c", "IOPlatformExpertDevice"},
+	}
+	out, err := helpers.ExecuteWithNoOutput(ctx.Context(), cmd)
 	if err != nil {
 		return "", err
 	}
@@ -382,7 +421,12 @@ func (s *SystemService) getUniqueIdMac(ctx basecontext.ApiContext) (string, erro
 }
 
 func (s *SystemService) getUniqueIdLinux(ctx basecontext.ApiContext) (string, error) {
-	out, err := commands.ExecuteWithNoOutput("cat", "/etc/machine-id")
+	cmd := helpers.Command{
+		Command: "cat",
+		Args:    []string{"/etc/machine-id"},
+	}
+
+	out, err := helpers.ExecuteWithNoOutput(ctx.Context(), cmd)
 	if err != nil {
 		return "", err
 	}
@@ -391,7 +435,12 @@ func (s *SystemService) getUniqueIdLinux(ctx basecontext.ApiContext) (string, er
 }
 
 func (s *SystemService) getUniqueIdWindows(ctx basecontext.ApiContext) (string, error) {
-	out, err := commands.ExecuteWithNoOutput("wmic", "path", "win32_computersystemproduct", "get", "UUID")
+	cmd := helpers.Command{
+		Command: "wmic",
+		Args:    []string{"path", "win32_computersystemproduct", "get", "UUID"},
+	}
+
+	out, err := helpers.ExecuteWithNoOutput(ctx.Context(), cmd)
 	if err != nil {
 		return "", err
 	}
@@ -412,7 +461,11 @@ func (s *SystemService) ChangeFileUserOwner(ctx basecontext.ApiContext, userName
 }
 
 func (s *SystemService) changeMacFileUserOwner(userName string, filePath string) error {
-	_, err := commands.ExecuteWithNoOutput("chown", "-R", userName, filePath)
+	cmd := helpers.Command{
+		Command: "chown",
+		Args:    []string{"-R", userName, filePath},
+	}
+	_, err := helpers.ExecuteWithNoOutput(s.ctx.Context(), cmd)
 	if err != nil {
 		return err
 	}
@@ -421,7 +474,11 @@ func (s *SystemService) changeMacFileUserOwner(userName string, filePath string)
 }
 
 func (s *SystemService) changeLinuxFileUserOwner(userName string, filePath string) error {
-	_, err := commands.ExecuteWithNoOutput("chown", "-R", userName, filePath)
+	cmd := helpers.Command{
+		Command: "chown",
+		Args:    []string{"-R", userName, filePath},
+	}
+	_, err := helpers.ExecuteWithNoOutput(s.ctx.Context(), cmd)
 	if err != nil {
 		return err
 	}
@@ -466,27 +523,27 @@ func (s *SystemService) getMacSystemHardwareInfo(ctx basecontext.ApiContext) (*m
 		Command: "df",
 		Args:    []string{"-h", "/"},
 	}
-	cpuBrand, err := helpers.ExecuteWithNoOutput(cpuBrandNameCmd)
+	cpuBrand, err := helpers.ExecuteWithNoOutput(s.ctx.Context(), cpuBrandNameCmd)
 	if err != nil {
 		return nil, err
 	}
-	cpuType, err := helpers.ExecuteWithNoOutput(cpuTypeCmd)
+	cpuType, err := helpers.ExecuteWithNoOutput(s.ctx.Context(), cpuTypeCmd)
 	if err != nil {
 		return nil, err
 	}
-	physicalCpuCount, err := helpers.ExecuteWithNoOutput(physicalCpuCountCmd)
+	physicalCpuCount, err := helpers.ExecuteWithNoOutput(s.ctx.Context(), physicalCpuCountCmd)
 	if err != nil {
 		return nil, err
 	}
-	logicalCpuCount, err := helpers.ExecuteWithNoOutput(logicalCpuCountCmd)
+	logicalCpuCount, err := helpers.ExecuteWithNoOutput(s.ctx.Context(), logicalCpuCountCmd)
 	if err != nil {
 		return nil, err
 	}
-	memorySize, err := helpers.ExecuteWithNoOutput(memorySizeCmd)
+	memorySize, err := helpers.ExecuteWithNoOutput(s.ctx.Context(), memorySizeCmd)
 	if err != nil {
 		return nil, err
 	}
-	diskAvailable, err := helpers.ExecuteWithNoOutput(diskAvailableCmd)
+	diskAvailable, err := helpers.ExecuteWithNoOutput(s.ctx.Context(), diskAvailableCmd)
 	if err != nil {
 		return nil, err
 	}
@@ -552,7 +609,7 @@ func (s *SystemService) getMacArchitecture(ctx basecontext.ApiContext) (string, 
 		Command: "uname",
 		Args:    []string{"-m"},
 	}
-	cpuType, err := helpers.ExecuteWithNoOutput(cpuTypeCmd)
+	cpuType, err := helpers.ExecuteWithNoOutput(s.ctx.Context(), cpuTypeCmd)
 	if err != nil {
 		return "", err
 	}
@@ -564,7 +621,7 @@ func (s *SystemService) getLinuxArchitecture(ctx basecontext.ApiContext) (string
 		Command: "uname",
 		Args:    []string{"-m"},
 	}
-	cpuType, err := helpers.ExecuteWithNoOutput(cpuTypeCmd)
+	cpuType, err := helpers.ExecuteWithNoOutput(s.ctx.Context(), cpuTypeCmd)
 	if err != nil {
 		return "", err
 	}

--- a/src/serviceprovider/vagrant/main.go
+++ b/src/serviceprovider/vagrant/main.go
@@ -14,7 +14,6 @@ import (
 	"github.com/Parallels/prl-devops-service/serviceprovider/interfaces"
 	"github.com/Parallels/prl-devops-service/serviceprovider/system"
 
-	"github.com/cjlapao/common-go/commands"
 	"github.com/cjlapao/common-go/helper"
 )
 
@@ -54,7 +53,12 @@ func (s *VagrantService) Name() string {
 
 func (s *VagrantService) FindPath() string {
 	s.ctx.LogInfof("Getting vagrant executable")
-	out, err := commands.ExecuteWithNoOutput("which", "vagrant")
+	cmd := helpers.Command{
+		Command: "which",
+		Args:    []string{"vagrant"},
+	}
+
+	out, err := helpers.ExecuteWithNoOutput(s.ctx.Context(), cmd)
 	path := strings.ReplaceAll(strings.TrimSpace(out), "\n", "")
 	if err != nil || path == "" {
 		s.ctx.LogWarnf("Vagrant executable not found, trying to find it in the default locations")
@@ -85,7 +89,7 @@ func (s *VagrantService) Version() string {
 		Args:    []string{"version"},
 	}
 
-	stdout, _, _, err := helpers.ExecuteWithOutput(cmd)
+	stdout, _, _, err := helpers.ExecuteWithOutput(s.ctx.Context(), cmd)
 	if err != nil {
 		return "unknown"
 	}
@@ -133,7 +137,7 @@ func (s *VagrantService) Install(asUser, version string, flags map[string]string
 	}
 
 	s.ctx.LogInfof("Installing %s with command: %v", s.Name(), cmd.String())
-	_, err := helpers.ExecuteWithNoOutput(cmd)
+	_, err := helpers.ExecuteWithNoOutput(s.ctx.Context(), cmd)
 	if err != nil {
 		return err
 	}
@@ -162,7 +166,7 @@ func (s *VagrantService) Uninstall(asUser string, uninstallDependencies bool) er
 			}
 		}
 
-		_, err := helpers.ExecuteWithNoOutput(cmd)
+		_, err := helpers.ExecuteWithNoOutput(s.ctx.Context(), cmd)
 		if err != nil {
 			return err
 		}
@@ -218,7 +222,7 @@ func (s *VagrantService) InstallParallelsDesktopPlugin(asUser string) error {
 			}
 		}
 
-		_, err := helpers.ExecuteWithNoOutput(cmd)
+		_, err := helpers.ExecuteWithNoOutput(s.ctx.Context(), cmd)
 		if err != nil {
 			return err
 		}
@@ -242,7 +246,7 @@ func (s *VagrantService) UpdatePlugins(asUser string) error {
 			}
 		}
 
-		_, err := helpers.ExecuteWithNoOutput(cmd)
+		_, err := helpers.ExecuteWithNoOutput(s.ctx.Context(), cmd)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
# Description

### Fixed

- Fixed an issue where we were trying to get the virtual machines for other users
  when not being a super admin
  
### Changed

- Moved database saving process to a 5 minutes setting to avoid overloading the
  database with too many requests
- Changed the way the orchestrator was checking for VMs status changes to avoid
  overloading the database
- Moved all the old commands to the new exec with context to enable timeouts
- Added a 30 seconds timeout when checking the status of the local vms

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md file accordingly
