### PR TITLE
issue with get hardware info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [0.8.5] - 2024-07-09
+
+### Fixed
+
+- Issue where the hardware info would crash if only one VM was present
+
 ## [0.8.4] - 2024-06-19
 
 ### Fixed

--- a/src/serviceprovider/parallelsdesktop/main.go
+++ b/src/serviceprovider/parallelsdesktop/main.go
@@ -1671,7 +1671,12 @@ func (s *ParallelsService) RunCustomCommand(ctx basecontext.ApiContext, vm *mode
 }
 
 func (s *ParallelsService) GetHardwareUsage(ctx basecontext.ApiContext) (*models.SystemUsageResponse, error) {
-	result := &models.SystemUsageResponse{}
+	result := &models.SystemUsageResponse{
+		TotalInUse:     &models.SystemUsageItem{},
+		TotalReserved:  &models.SystemUsageItem{},
+		SystemReserved: &models.SystemUsageItem{},
+		Total:          &models.SystemUsageItem{},
+	}
 
 	vms, err := s.GetCachedVms(ctx, "")
 	if err != nil {


### PR DESCRIPTION
# Description

- Fixed an issue where the hardware info would crash if only one VM was present


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md file accordingly
