### PR TITLE
[helm] allow sourcing env vars from secret or config maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `envFrom` key to Helm values
+
 ### Fixed
 
 ### Changed
@@ -98,7 +100,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Generation of the Helm Charts
 - Issue where some missing details in telemetry would crash
-  
+
 ### Changed
 
 - Added better readme documentation
@@ -142,7 +144,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   overloading the database
 - Moved all the old commands to the new exec with context to enable timeouts
 - Added a 30 seconds timeout when checking the status of the local vms
-  
+
 ## [0.7.1] - 2024-05-29
 
 ### Added
@@ -175,7 +177,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed a issue with the orchestrator where it didn't start the auto refresh
-  
+
 ## [0.6.6] - 2024-05-16
 
 ### Fixed
@@ -243,7 +245,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved documentation on GitHub Actions and Orchestrator use cases
 - Added Start/Stop endpoints to the orchestrator
 - Added Amplitude Key to the docker images
-  
+
 ### Fixed
 
 - Fixed several issues with the orchestrator

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -46,162 +46,166 @@ spec:
               value: {{ .Values.service.targetPort | quote }}
             {{- if .Values.apiPrefix }}
             - name: API_PREFIX
-              valueFrom: 
+              valueFrom:
                 configMapKeyRef:
                   name: {{ include "helm.fullname" . }}
                   key: API_PREFIX
             {{- end }}
             {{- if .Values.logLevel }}
             - name: LOG_LEVEL
-              valueFrom: 
+              valueFrom:
                 configMapKeyRef:
                   name: {{ include "helm.fullname" . }}
                   key: LOG_LEVEL
             {{- end }}
             {{- if .Values.security.key }}
-            - name: ENCRYPTION_PRIVATE_KEY 
-              valueFrom: 
+            - name: ENCRYPTION_PRIVATE_KEY
+              valueFrom:
                 secretKeyRef:
                   name: {{ include "helm.fullname" . }}
                   key: ENCRYPTION_PRIVATE_KEY
             {{- end }}
             {{- if .Values.security.jwt.hmac_secret }}
-            - name: JWT_HMACS_SECRET 
-              valueFrom: 
+            - name: JWT_HMACS_SECRET
+              valueFrom:
                 secretKeyRef:
                   name: {{ include "helm.fullname" . }}
                   key: JWT_HMACS_SECRET
             {{- end }}
             {{- if .Values.security.jwt.rsa_private_key }}
-            - name: JWT_PRIVATE_KEY 
-              valueFrom: 
+            - name: JWT_PRIVATE_KEY
+              valueFrom:
                 secretKeyRef:
                   name: {{ include "helm.fullname" . }}
                   key: JWT_PRIVATE_KEY
             {{- end }}
             {{- if .Values.security.jwt.duration }}
             - name: JWT_DURATION
-              valueFrom: 
+              valueFrom:
                 configMapKeyRef:
                   name: {{ include "helm.fullname" . }}
                   key: JWT_DURATION
             {{- end }}
             {{- if .Values.security.jwt.signing_method }}
             - name: JWT_SIGN_ALGORITHM
-              valueFrom: 
+              valueFrom:
                 configMapKeyRef:
                   name: {{ include "helm.fullname" . }}
                   key: JWT_SIGN_ALGORITHM
             {{- end }}
             {{- if .Values.security.password.min_password_length }}
             - name: SECURITY_PASSWORD_MIN_PASSWORD_LENGTH
-              valueFrom: 
+              valueFrom:
                 configMapKeyRef:
                   name: {{ include "helm.fullname" . }}
                   key: SECURITY_PASSWORD_MIN_PASSWORD_LENGTH
             {{- end }}
             {{- if .Values.security.password.max_password_length }}
             - name: SECURITY_PASSWORD_MAX_PASSWORD_LENGTH
-              valueFrom: 
+              valueFrom:
                 configMapKeyRef:
                   name: {{ include "helm.fullname" . }}
                   key: SECURITY_PASSWORD_MAX_PASSWORD_LENGTH
             {{- end }}
             {{- if .Values.security.password.require_lowercase }}
             - name: SECURITY_PASSWORD_REQUIRE_LOWERCASE
-              valueFrom: 
+              valueFrom:
                 configMapKeyRef:
                   name: {{ include "helm.fullname" . }}
                   key: SECURITY_PASSWORD_REQUIRE_LOWERCASE
             {{- end }}
             {{- if .Values.security.password.require_uppercase }}
             - name: SECURITY_PASSWORD_REQUIRE_UPPERCASE
-              valueFrom: 
+              valueFrom:
                 configMapKeyRef:
                   name: {{ include "helm.fullname" . }}
                   key: SECURITY_PASSWORD_REQUIRE_UPPERCASE
             {{- end }}
             {{- if .Values.security.password.require_number }}
             - name: SECURITY_PASSWORD_REQUIRE_NUMBER
-              valueFrom: 
+              valueFrom:
                 configMapKeyRef:
                   name: {{ include "helm.fullname" . }}
                   key: SECURITY_PASSWORD_REQUIRE_NUMBER
             {{- end }}
             {{- if .Values.security.password.require_special_characters }}
             - name: SECURITY_PASSWORD_REQUIRE_SPECIAL_CHAR
-              valueFrom: 
+              valueFrom:
                 configMapKeyRef:
                   name: {{ include "helm.fullname" . }}
                   key: SECURITY_PASSWORD_REQUIRE_SPECIAL_CHAR
             {{- end }}
             {{- if .Values.security.password.salt_password }}
             - name: SECURITY_PASSWORD_SALT_PASSWORD
-              valueFrom: 
+              valueFrom:
                 configMapKeyRef:
                   name: {{ include "helm.fullname" . }}
                   key: SECURITY_PASSWORD_SALT_PASSWORD
             {{- end }}
             {{- if .Values.security.brute_force.max_login_attempts }}
             - name: BRUTE_FORCE_MAX_LOGIN_ATTEMPTS
-              valueFrom: 
+              valueFrom:
                 configMapKeyRef:
                   name: {{ include "helm.fullname" . }}
                   key: BRUTE_FORCE_MAX_LOGIN_ATTEMPTS
             {{- end }}
             {{- if .Values.security.brute_force.lockout_duration }}
             - name: BRUTE_FORCE_LOCKOUT_DURATION
-              valueFrom: 
+              valueFrom:
                 configMapKeyRef:
                   name: {{ include "helm.fullname" . }}
                   key: BRUTE_FORCE_LOCKOUT_DURATION
             {{- end }}
             {{- if .Values.security.brute_force.increment_lockout_duration }}
             - name: BRUTE_FORCE_INCREMENTAL_WAIT
-              valueFrom: 
+              valueFrom:
                 configMapKeyRef:
                   name: {{ include "helm.fullname" . }}
                   key: BRUTE_FORCE_INCREMENTAL_WAIT
             {{- end }}
             {{- if .Values.security.root_password }}
-            - name: ROOT_PASSWORD 
-              valueFrom: 
+            - name: ROOT_PASSWORD
+              valueFrom:
                 secretKeyRef:
                   name: {{ include "helm.fullname" . }}
                   key: SECURITY_ROOT_PASSWORD
             {{- end }}
             {{- if .Values.security.enable_tls }}
-            - name: TLS_ENABLED 
+            - name: TLS_ENABLED
               value: "true"
-            - name: TLS_CERTIFICATE 
-              valueFrom: 
+            - name: TLS_CERTIFICATE
+              valueFrom:
                 secretKeyRef:
                   name: {{ include "helm.fullname" . }}
                   key: TLS_CERTIFICATE
-            - name: TLS_PRIVATE_KEY 
-              valueFrom: 
+            - name: TLS_PRIVATE_KEY
+              valueFrom:
                 secretKeyRef:
                   name: {{ include "helm.fullname" . }}
                   key: TLS_PRIVATE_KEY
             {{- end }}
             {{- if .Values.config.disableCatalogCaching }}
-            - name: DISABLE_CATALOG_CACHING 
+            - name: DISABLE_CATALOG_CACHING
               value: "true"
             {{- end }}
             {{- if .Values.config.mode }}
             - name: MODE
-              valueFrom: 
+              valueFrom:
                 configMapKeyRef:
                   name: {{ include "helm.fullname" . }}
                   key: MODE
             {{- end }}
             {{- if .Values.storage.databasePath }}
             - name: DATABASE_FOLDER
-              valueFrom: 
+              valueFrom:
                 configMapKeyRef:
                   name: {{ include "helm.fullname" . }}
                   key: DATABASE_FOLDER
             {{- end }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.targetPort }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -29,6 +29,10 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
+envFrom: []
+  # - secretRef:
+  #     name: mySecret
+
 storage:
   node_name: ''
   storage_class: 'manual'
@@ -114,4 +118,3 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
-


### PR DESCRIPTION
# Description

Adds option to source environment variables from Secret or ConfigMap ref. This allows pulling in secrets from outside of a static Helm values file in cases of using something like ExternalSecret provider or other.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

### Checklist

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have run tests that prove my fix is effective or that my feature works
- [X] I have updated the CHANGELOG.md file accordingly
