### PR TITLE
Fix issue with the applevm limitations

### DIFF
--- a/src/catalog/models/catalog_manifest_provider.go
+++ b/src/catalog/models/catalog_manifest_provider.go
@@ -182,6 +182,15 @@ func (m *CatalogManifestProvider) Parse(connection string) error {
 			m.Username = ""
 			m.Password = ""
 		}
+
+		if strings.HasPrefix(parts[1], "http://") || strings.HasPrefix(parts[1], "https://") {
+			schemaParts := strings.Split(parts[1], "://")
+			if len(schemaParts) == 2 {
+				schema = schemaParts[0]
+				parts[1] = schemaParts[1]
+			}
+		}
+
 		if strings.ContainsAny(parts[1], ":") {
 			hostParts := strings.Split(parts[1], ":")
 			if len(hostParts) == 2 {
@@ -192,9 +201,7 @@ func (m *CatalogManifestProvider) Parse(connection string) error {
 			m.Host = parts[1]
 		}
 	}
-	if schema != "" {
-		m.Host = schema + "://" + m.Host
-	}
+
 	if strings.Contains(m.Host, ":") {
 		lastIndexOfAt := strings.LastIndex(m.Host, ":")
 		hostParts := []string{m.Host[:lastIndexOfAt], m.Host[lastIndexOfAt+1:]}
@@ -202,6 +209,10 @@ func (m *CatalogManifestProvider) Parse(connection string) error {
 			m.Host = hostParts[0]
 			m.Port = hostParts[1]
 		}
+	}
+
+	if schema != "" {
+		m.Host = schema + "://" + m.Host
 	}
 
 	return nil

--- a/src/data/models/host_resources.go
+++ b/src/data/models/host_resources.go
@@ -4,6 +4,7 @@ type HostResourceOverviewResponseItem struct {
 	CpuType        string            `json:"cpu_type,omitempty"`
 	CpuBrand       string            `json:"cpu_brand,omitempty"`
 	ReverseProxy   *HostReverseProxy `json:"reverse_proxy,omitempty"`
+	TotalAppleVms  int64             `json:"total_apple_vms,omitempty"`
 	Total          HostResourceItem  `json:"total,omitempty"`
 	TotalAvailable HostResourceItem  `json:"total_available,omitempty"`
 	TotalInUse     HostResourceItem  `json:"total_in_use,omitempty"`
@@ -14,6 +15,7 @@ type HostResources struct {
 	CpuType        string            `json:"cpu_type,omitempty"`
 	CpuBrand       string            `json:"cpu_brand,omitempty"`
 	ReverseProxy   *HostReverseProxy `json:"reverse_proxy,omitempty"`
+	TotalAppleVms  int64             `json:"total_apple_vms,omitempty"`
 	Total          HostResourceItem  `json:"total,omitempty"`
 	TotalAvailable HostResourceItem  `json:"total_available,omitempty"`
 	TotalInUse     HostResourceItem  `json:"total_in_use,omitempty"`
@@ -36,12 +38,16 @@ func (c *HostResources) Diff(source HostResources) bool {
 	if c.TotalReserved.Diff(source.TotalReserved) {
 		return true
 	}
+	if c.TotalAppleVms != source.TotalAppleVms {
+		return true
+	}
 
 	return false
 }
 
 type HostResourceItem struct {
 	CpuType          string  `json:"cpu_type,omitempty"`
+	TotalAppleVms    int64   `json:"total_apple_vms,omitempty"`
 	PhysicalCpuCount int64   `json:"physical_cpu_count,omitempty"`
 	LogicalCpuCount  int64   `json:"logical_cpu_count"`
 	MemorySize       float64 `json:"memory_size,omitempty"`
@@ -63,6 +69,9 @@ func (c *HostResourceItem) Diff(source HostResourceItem) bool {
 		return true
 	}
 	if c.FreeDiskSize != source.FreeDiskSize {
+		return true
+	}
+	if c.TotalAppleVms != source.TotalAppleVms {
 		return true
 	}
 

--- a/src/data/orchestrator.go
+++ b/src/data/orchestrator.go
@@ -350,6 +350,7 @@ func (j *JsonDatabase) GetOrchestratorReservedResources(ctx basecontext.ApiConte
 					result[host.Resources.CpuType] = models.HostResourceItem{}
 				}
 				item := result[host.Resources.CpuType]
+				item.TotalAppleVms += host.Resources.TotalAppleVms
 				item.LogicalCpuCount += host.Resources.TotalReserved.LogicalCpuCount
 				item.PhysicalCpuCount += host.Resources.TotalReserved.PhysicalCpuCount
 				item.FreeDiskSize += host.Resources.TotalReserved.FreeDiskSize

--- a/src/mappers/orchestrator.go
+++ b/src/mappers/orchestrator.go
@@ -30,6 +30,7 @@ func DtoOrchestratorHostToApiResponse(dto data_models.OrchestratorHost) models.O
 
 	if dto.Resources != nil {
 		result.Resources = DtoOrchestratorResourceItemToApi(dto.Resources.Total)
+		result.Resources.TotalAppleVms = dto.Resources.TotalAppleVms
 	}
 
 	if dto.ReverseProxy != nil {
@@ -94,6 +95,7 @@ func ApiOrchestratorAuthenticationToDto(request models.OrchestratorAuthenticatio
 
 func DtoOrchestratorResourceItemToApi(dto data_models.HostResourceItem) models.HostResourceItem {
 	result := models.HostResourceItem{
+		TotalAppleVms:    dto.TotalAppleVms,
 		PhysicalCpuCount: dto.PhysicalCpuCount,
 		LogicalCpuCount:  dto.LogicalCpuCount,
 		MemorySize:       dto.MemorySize,
@@ -106,6 +108,7 @@ func DtoOrchestratorResourceItemToApi(dto data_models.HostResourceItem) models.H
 
 func ApiOrchestratorResourceItemToDto(request models.HostResourceItem) data_models.HostResourceItem {
 	result := data_models.HostResourceItem{
+		TotalAppleVms:    request.TotalAppleVms,
 		PhysicalCpuCount: request.PhysicalCpuCount,
 		LogicalCpuCount:  request.LogicalCpuCount,
 		MemorySize:       request.MemorySize,

--- a/src/models/create_vritual_machine_specs.go
+++ b/src/models/create_vritual_machine_specs.go
@@ -3,6 +3,7 @@ package models
 import "strconv"
 
 type CreateVirtualMachineSpecs struct {
+	Type   string `json:"type,omitempty"`
 	Cpu    string `json:"cpu,omitempty"`
 	Memory string `json:"memory,omitempty"`
 	Disk   string `json:"disk,omitempty"`

--- a/src/models/orchestrator_host.go
+++ b/src/models/orchestrator_host.go
@@ -9,6 +9,7 @@ import (
 )
 
 type HostResourceItem struct {
+	TotalAppleVms    int64   `json:"total_apple_vms,omitempty"`
 	PhysicalCpuCount int64   `json:"physical_cpu_count,omitempty"`
 	LogicalCpuCount  int64   `json:"logical_cpu_count"`
 	MemorySize       float64 `json:"memory_size,omitempty"`

--- a/src/orchestrator/common.go
+++ b/src/orchestrator/common.go
@@ -6,7 +6,8 @@ import (
 )
 
 const (
-	HealthyState = "healthy"
+	HealthyState      = "healthy"
+	MaxNumberAppleVms = 2
 )
 
 func (s *OrchestratorService) getApiClient(request models.OrchestratorHost) *apiclient.HttpClientService {

--- a/src/orchestrator/main.go
+++ b/src/orchestrator/main.go
@@ -208,6 +208,15 @@ func (s *OrchestratorService) processHost(host models.OrchestratorHost) {
 		host.VirtualMachines = append(host.VirtualMachines, dtoVm)
 	}
 
+	totalAppleVms := 0
+	for _, vm := range host.VirtualMachines {
+		if vm.Type == "APPLE_VZ_VM" {
+			totalAppleVms++
+		}
+	}
+
+	host.Resources.TotalAppleVms = int64(totalAppleVms)
+
 	_ = s.persistHost(&host)
 
 	// Free up memory


### PR DESCRIPTION
# Description

- Fixed an issue where the orchestrator would not take into account the 2 vms limitation when gathering the necessary space [fixes #229]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md file accordingly
