### PR TITLE
Fix a bug on execute endpoint

### DIFF
--- a/src/models/virtual_machine_execute.go
+++ b/src/models/virtual_machine_execute.go
@@ -12,7 +12,7 @@ type VirtualMachineExecuteCommandRequest struct {
 }
 
 func (r *VirtualMachineExecuteCommandRequest) Validate() error {
-	if r.Command == "" || r.Script == nil {
+	if r.Command == "" && r.Script == nil {
 		if r.Script == nil {
 			return errors.NewWithCode("missing script", 400)
 		}


### PR DESCRIPTION
# Description

- Fixed a bug on the execute endpoint where it would give an error if the command was present but the script was not
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md file accordingly
