### PR TITLE
Fixing the issues with the reverse proxy

### DIFF
--- a/src/config/main.go
+++ b/src/config/main.go
@@ -506,29 +506,25 @@ func (c *Config) IsReverseProxyEnabled() bool {
 	return true
 }
 
-func (c *Config) GetReverseProxyConfig() *ReverseProxyConfig {
-	if c.config.ReverseProxy == nil {
-		c.config.ReverseProxy = &ReverseProxyConfig{
-			Host: "localhost",
-			Port: "8080",
-		}
-		if c.TlsEnabled() {
-			c.config.ReverseProxy.Ssl = &ReverseProxyConfigSsl{
-				Enabled: true,
-				Cert:    c.TlsCertificate(),
-				Key:     c.TlsPrivateKey(),
-			}
-		}
-		if c.IsCorsEnabled() {
-			c.config.ReverseProxy.Cors = &ReverseProxyConfigCors{
-				Enabled:        true,
-				AllowedOrigins: []string{"*"},
-				AllowedMethods: []string{"GET", "POST", "PUT", "DELETE", "OPTIONS", "HEAD", "PATCH", "CONNECT", "TRACE"},
-				AllowedHeaders: []string{"*"},
-			}
-		}
+func (c *Config) ReverseProxyHost() string {
+	host := c.GetKey(constants.REVERSE_PROXY_HOST_ENV_VAR)
+	if host == "" {
+		host = constants.DEFAULT_REVERSE_PROXY_HOST
 	}
 
+	return host
+}
+
+func (c *Config) ReverseProxyPort() string {
+	port := c.GetKey(constants.REVERSE_PROXY_PORT_ENV_VAR)
+	if port == "" {
+		port = constants.DEFAULT_REVERSE_PROXY_PORT
+	}
+
+	return port
+}
+
+func (c *Config) GetReverseProxyConfig() *ReverseProxyConfig {
 	return c.config.ReverseProxy
 }
 

--- a/src/constants/main.go
+++ b/src/constants/main.go
@@ -38,6 +38,8 @@ const (
 	DEFAULT_SYSTEM_RESERVED_CPU             = 1
 	DEFAULT_SYSTEM_RESERVED_MEMORY          = 2048
 	DEFAULT_SYSTEM_RESERVED_DISK            = 20000
+	DEFAULT_REVERSE_PROXY_PORT              = "5080"
+	DEFAULT_REVERSE_PROXY_HOST              = "0.0.0.0"
 
 	API_MODE          = "api"
 	CLI_MODE          = "cli"

--- a/src/data/models/reverse_proxy.go
+++ b/src/data/models/reverse_proxy.go
@@ -6,14 +6,18 @@ import (
 )
 
 type ReverseProxy struct {
-	ID     string `json:"id"`
-	HostID string `json:"host_id,omitempty"`
-	Host   string `json:"host"`
-	Port   string `json:"port"`
+	ID      string `json:"id"`
+	HostID  string `json:"host_id,omitempty"`
+	Enabled bool   `json:"enabled"`
+	Host    string `json:"host"`
+	Port    string `json:"port"`
 }
 
 func (o *ReverseProxy) Diff(source ReverseProxy) bool {
 	if o == nil {
+		return true
+	}
+	if o.Enabled != source.Enabled {
 		return true
 	}
 	if o.Host != source.Host {

--- a/src/data/reverse_proxy.go
+++ b/src/data/reverse_proxy.go
@@ -25,6 +25,34 @@ func (j *JsonDatabase) GetReverseProxyConfig(ctx basecontext.ApiContext) (*model
 	return j.data.ReverseProxy, nil
 }
 
+func (j *JsonDatabase) EnableProxyConfig(ctx basecontext.ApiContext) (*models.ReverseProxy, error) {
+	if !j.IsConnected() {
+		return nil, ErrDatabaseNotConnected
+	}
+
+	if j.data.ReverseProxy == nil {
+		return nil, errors.NewWithCode("reverse proxy config not found", 404)
+	}
+
+	j.data.ReverseProxy.Enabled = true
+
+	return j.data.ReverseProxy, nil
+}
+
+func (j *JsonDatabase) DisableProxyConfig(ctx basecontext.ApiContext) (*models.ReverseProxy, error) {
+	if !j.IsConnected() {
+		return nil, ErrDatabaseNotConnected
+	}
+
+	if j.data.ReverseProxy == nil {
+		return nil, errors.NewWithCode("reverse proxy config not found", 404)
+	}
+
+	j.data.ReverseProxy.Enabled = false
+
+	return j.data.ReverseProxy, nil
+}
+
 func (j *JsonDatabase) UpdateReverseProxy(ctx basecontext.ApiContext, rp models.ReverseProxy) (*models.ReverseProxy, error) {
 	if !j.IsConnected() {
 		return nil, ErrDatabaseNotConnected
@@ -32,6 +60,11 @@ func (j *JsonDatabase) UpdateReverseProxy(ctx basecontext.ApiContext, rp models.
 
 	if j.data.ReverseProxy.Diff(rp) {
 		rpCopy := rp
+		if j.data.ReverseProxy != nil {
+			rpCopy.ID = j.data.ReverseProxy.ID
+		} else {
+			rpCopy.ID = helpers.GenerateId()
+		}
 		j.data.ReverseProxy = &rpCopy
 		_ = j.SaveNow(ctx)
 		return &rp, nil

--- a/src/mappers/reverse_proxy.go
+++ b/src/mappers/reverse_proxy.go
@@ -1,9 +1,9 @@
 package mappers
 
 import (
-	config_models "github.com/Parallels/prl-devops-service/config"
 	data_models "github.com/Parallels/prl-devops-service/data/models"
 	"github.com/Parallels/prl-devops-service/models"
+	rp_models "github.com/Parallels/prl-devops-service/reverse_proxy/models"
 )
 
 func DtoReverseProxyToApi(m data_models.ReverseProxy) models.ReverseProxy {
@@ -24,10 +24,11 @@ func ApiReverseProxyToDto(m models.ReverseProxy) data_models.ReverseProxy {
 	return r
 }
 
-func ConfigReverseProxyToDto(m config_models.ReverseProxyConfig) data_models.ReverseProxy {
+func ConfigReverseProxyToDto(m rp_models.ReverseProxyConfig) data_models.ReverseProxy {
 	r := data_models.ReverseProxy{
-		Host: m.Host,
-		Port: m.Port,
+		Enabled: m.Enabled,
+		Host:    m.Host,
+		Port:    m.Port,
 	}
 
 	return r

--- a/src/reverse_proxy/models/config.go
+++ b/src/reverse_proxy/models/config.go
@@ -1,0 +1,8 @@
+package models
+
+type ReverseProxyConfig struct {
+	ID      string `json:"-"`
+	Enabled bool   `json:"enabled" yaml:"enabled"`
+	Host    string `json:"host,omitempty" yaml:"host,omitempty"`
+	Port    string `json:"port,omitempty" yaml:"port,omitempty"`
+}


### PR DESCRIPTION
# Description

- Fixed an issue where the reverse proxy would fail to initialize due to prot conflict and any attempt to restart would crash
- fixed an issue where we allowed routes to be created even if the reverse proxy was disabled
- fixed an issue where if the config changes in memory we would not save those changes
- added the ability to choose the port and host trough configuration or env variables

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md file accordingly
