### PR TITLE
227 - Enable the ability to upload files to VMs

### DIFF
--- a/src/helpers/version.go
+++ b/src/helpers/version.go
@@ -1,0 +1,33 @@
+package helpers
+
+import (
+	"fmt"
+)
+
+type Version struct {
+	Major int
+	Minor int
+	Patch int
+}
+
+func NewVersion(version string) *Version {
+	v := &Version{}
+	fmt.Sscanf(version, "%d.%d.%d", &v.Major, &v.Minor, &v.Patch)
+	return v
+}
+
+func (v *Version) LessThan(other *Version) bool {
+	if v.Major < other.Major {
+		return true
+	}
+	if v.Major > other.Major {
+		return false
+	}
+	if v.Minor < other.Minor {
+		return true
+	}
+	if v.Minor > other.Minor {
+		return false
+	}
+	return v.Patch < other.Patch
+}

--- a/src/helpers/version_test.go
+++ b/src/helpers/version_test.go
@@ -1,0 +1,42 @@
+package helpers
+
+import (
+	"testing"
+)
+
+func TestVersionLessThan(t *testing.T) {
+	testCases := []struct {
+		name     string
+		v1       *Version
+		v2       *Version
+		expected bool
+	}{
+		{
+			name:     "v1 < v2",
+			v1:       NewVersion("1.0.0"),
+			v2:       NewVersion("1.1.0"),
+			expected: true,
+		},
+		{
+			name:     "v1 > v2",
+			v1:       NewVersion("2.0.0"),
+			v2:       NewVersion("1.1.0"),
+			expected: false,
+		},
+		{
+			name:     "v1 = v2",
+			v1:       NewVersion("1.1.0"),
+			v2:       NewVersion("1.1.0"),
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.v1.LessThan(tc.v2)
+			if actual != tc.expected {
+				t.Errorf("Expected %t, but got %t", tc.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

 - Added the new prlcopy script if PD 20.2.0 or above, system will use 'prlcopy' binary else, system will try to compress and upload the file using exec command, Fixes #227 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

### Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (N/A)
- [x] My changes generate no new warnings
- [x] I have run tests that prove my fix is effective or that my feature works
- [ ] I have updated the CHANGELOG.md file accordingly
