### PR TITLE
Add MinIO compatibility

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,6 +11,7 @@
       "envFile": "${workspaceFolder}/.env",
       "args": [
         "${input:debug_command}",
+        "catalog-providers",
       ]
     },
     {

--- a/src/catalog/main.go
+++ b/src/catalog/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Parallels/prl-devops-service/catalog/providers/aws_s3_bucket"
 	"github.com/Parallels/prl-devops-service/catalog/providers/azurestorageaccount"
 	"github.com/Parallels/prl-devops-service/catalog/providers/local"
+	"github.com/Parallels/prl-devops-service/catalog/providers/minio"
 	"github.com/Parallels/prl-devops-service/compressor"
 	"github.com/Parallels/prl-devops-service/errors"
 	"github.com/Parallels/prl-devops-service/helpers"
@@ -51,6 +52,7 @@ func NewManifestService(ctx basecontext.ApiContext) *CatalogManifestService {
 	manifestService.AddRemoteService(local.NewLocalProvider())
 	manifestService.AddRemoteService(azurestorageaccount.NewAzureStorageAccountProvider())
 	manifestService.AddRemoteService(artifactory.NewArtifactoryProvider())
+	manifestService.AddRemoteService(minio.NewMinioProvider())
 	return manifestService
 }
 

--- a/src/catalog/providers/minio/chunk_downloader.go
+++ b/src/catalog/providers/minio/chunk_downloader.go
@@ -1,0 +1,70 @@
+package minio
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+)
+
+type MinioChunkDownloader struct {
+	bucket     string
+	svc        s3iface.S3API
+	bucketPath string
+}
+
+func NewMinioChunkDownloader(bucket, bucketPath string, s3Service s3iface.S3API) *MinioChunkDownloader {
+	return &MinioChunkDownloader{
+		bucket:     bucket,
+		svc:        s3Service,
+		bucketPath: bucketPath,
+	}
+}
+
+func (d *MinioChunkDownloader) GetFileSize(ctx context.Context, path string) (int64, error) {
+	remoteFilePath := d.getRemoteFilePath(path)
+
+	headObjectOutput, err := d.svc.HeadObjectWithContext(ctx, &s3.HeadObjectInput{
+		Bucket: aws.String(d.bucket),
+		Key:    aws.String(remoteFilePath),
+	})
+	if err != nil {
+		return 0, fmt.Errorf("failed HeadObject: %w", err)
+	}
+
+	return *headObjectOutput.ContentLength, nil
+}
+
+func (d *MinioChunkDownloader) DownloadChunk(ctx context.Context, path string, start, end int64) (io.ReadCloser, error) {
+	remoteFilePath := d.getRemoteFilePath(path)
+	rangeHeader := fmt.Sprintf("bytes=%d-%d", start, end)
+
+	resp, err := d.svc.GetObjectWithContext(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(d.bucket),
+		Key:    aws.String(remoteFilePath),
+		Range:  aws.String(rangeHeader),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to download chunk range=%s: %w", rangeHeader, err)
+	}
+
+	return resp.Body, nil
+}
+
+func (d *MinioChunkDownloader) getRemoteFilePath(path string) string {
+	fullPath := path
+	if d.bucketPath != "" {
+		if !strings.HasPrefix(path, d.bucketPath) {
+			fullPath = filepath.Join(d.bucketPath, path)
+		}
+	}
+
+	fullPath = strings.TrimPrefix(fullPath, "/")
+
+	return fullPath
+}

--- a/src/catalog/providers/minio/chunk_downloader_test.go
+++ b/src/catalog/providers/minio/chunk_downloader_test.go
@@ -1,0 +1,115 @@
+package minio
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+)
+
+// MockMinioClient implements s3iface.S3API for testing
+type MockMinioClient struct {
+	s3iface.S3API
+	content      string
+	headErr      error
+	getObjectErr error
+}
+
+func (m *MockMinioClient) HeadObjectWithContext(ctx context.Context, input *s3.HeadObjectInput, opts ...request.Option) (*s3.HeadObjectOutput, error) {
+	if m.headErr != nil {
+		return nil, m.headErr
+	}
+	size := int64(len(m.content))
+	return &s3.HeadObjectOutput{
+		ContentLength: aws.Int64(size),
+	}, nil
+}
+
+func (m *MockMinioClient) GetObjectWithContext(ctx context.Context, input *s3.GetObjectInput, opts ...request.Option) (*s3.GetObjectOutput, error) {
+	if m.getObjectErr != nil {
+		return nil, m.getObjectErr
+	}
+
+	rangeStr := aws.StringValue(input.Range)
+	start, end := parseRange(rangeStr)
+	if end >= int64(len(m.content)) {
+		end = int64(len(m.content)) - 1
+	}
+
+	body := io.NopCloser(strings.NewReader(m.content[start : end+1]))
+	return &s3.GetObjectOutput{
+		Body: body,
+	}, nil
+}
+
+func parseRange(rangeStr string) (start, end int64) {
+	// Parse "bytes=start-end"
+	parts := strings.Split(strings.TrimPrefix(rangeStr, "bytes="), "-")
+	if len(parts) != 2 {
+		return 0, 0
+	}
+	fmt.Sscanf(parts[0], "%d", &start)
+	fmt.Sscanf(parts[1], "%d", &end)
+	return
+}
+
+func TestS3ChunkDownloader(t *testing.T) {
+	content := "Hello, this is a test content for S3 mock!"
+	mockS3 := &MockMinioClient{content: content}
+	downloader := NewMinioChunkDownloader("test-bucket", "test/path", mockS3)
+
+	t.Run("GetFileSize", func(t *testing.T) {
+		size, err := downloader.GetFileSize(context.Background(), "test.txt")
+		if err != nil {
+			t.Errorf("GetFileSize() error = %v", err)
+			return
+		}
+		if size != int64(len(content)) {
+			t.Errorf("GetFileSize() = %v, want %v", size, len(content))
+		}
+	})
+
+	t.Run("DownloadChunk", func(t *testing.T) {
+		reader, err := downloader.DownloadChunk(context.Background(), "test.txt", 0, 4)
+		if err != nil {
+			t.Errorf("DownloadChunk() error = %v", err)
+			return
+		}
+		defer reader.Close()
+
+		data, err := io.ReadAll(reader)
+		if err != nil {
+			t.Errorf("Failed to read chunk: %v", err)
+			return
+		}
+
+		if string(data) != "Hello" {
+			t.Errorf("DownloadChunk() = %v, want %v", string(data), "Hello")
+		}
+	})
+
+	t.Run("Error cases", func(t *testing.T) {
+		mockS3WithErrors := &MockMinioClient{
+			content:      content,
+			headErr:      fmt.Errorf("head error"),
+			getObjectErr: fmt.Errorf("get error"),
+		}
+		errorDownloader := NewMinioChunkDownloader("test-bucket", "test/path", mockS3WithErrors)
+
+		_, err := errorDownloader.GetFileSize(context.Background(), "test.txt")
+		if err == nil {
+			t.Error("GetFileSize() expected error, got nil")
+		}
+
+		_, err = errorDownloader.DownloadChunk(context.Background(), "test.txt", 0, 4)
+		if err == nil {
+			t.Error("DownloadChunk() expected error, got nil")
+		}
+	})
+}

--- a/src/catalog/providers/minio/main.go
+++ b/src/catalog/providers/minio/main.go
@@ -1,0 +1,787 @@
+package minio
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/Parallels/prl-devops-service/basecontext"
+	"github.com/Parallels/prl-devops-service/catalog/common"
+	"github.com/Parallels/prl-devops-service/compressor"
+	"github.com/Parallels/prl-devops-service/config"
+	"github.com/Parallels/prl-devops-service/helpers"
+	"github.com/Parallels/prl-devops-service/notifications"
+	"github.com/Parallels/prl-devops-service/writers"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/Parallels/prl-devops-service/catalog/chunkmanagerservice"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+)
+
+type MinioBucket struct {
+	Endpoint                     string
+	UseSSL                       bool
+	IgnoreCert                   bool
+	Name                         string
+	AccessKey                    string
+	SecretKey                    string
+	UseEnvironmentAuthentication string
+	ProgressChannel              chan int
+}
+
+const providerName = "minio"
+
+type MinioBucketProvider struct {
+	Bucket          MinioBucket
+	ProgressChannel chan int
+	FileNameChannel chan string
+}
+
+func NewMinioProvider() *MinioBucketProvider {
+	return &MinioBucketProvider{}
+}
+
+func (s *MinioBucketProvider) Name() string {
+	return providerName
+}
+
+func (s *MinioBucketProvider) GetProviderMeta(ctx basecontext.ApiContext) map[string]string {
+	return map[string]string{
+		common.PROVIDER_VAR_NAME:         providerName,
+		"endpoint":                       s.Bucket.Endpoint,
+		"use_ssl":                        strconv.FormatBool(s.Bucket.UseSSL),
+		"ignore_cert":                    strconv.FormatBool(s.Bucket.IgnoreCert),
+		"bucket":                         s.Bucket.Name,
+		"access_key":                     s.Bucket.AccessKey,
+		"secret_key":                     s.Bucket.SecretKey,
+		"use_environment_authentication": s.Bucket.UseEnvironmentAuthentication,
+	}
+}
+
+func (s *MinioBucketProvider) GetProviderRootPath(ctx basecontext.ApiContext) string {
+	return "/"
+}
+
+func (s *MinioBucketProvider) CanStream() bool {
+	return true
+}
+
+func (s *MinioBucketProvider) SetProgressChannel(fileNameChannel chan string, progressChannel chan int) {
+	s.ProgressChannel = progressChannel
+	s.FileNameChannel = fileNameChannel
+}
+
+func (s *MinioBucketProvider) Check(ctx basecontext.ApiContext, connection string) (bool, error) {
+	parts := strings.Split(connection, ";")
+	provider := ""
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if strings.Contains(strings.ToLower(part), common.PROVIDER_VAR_NAME+"=") {
+			provider = strings.ReplaceAll(part, common.PROVIDER_VAR_NAME+"=", "")
+		}
+		if strings.Contains(strings.ToLower(part), "bucket=") {
+			s.Bucket.Name = strings.ReplaceAll(part, "bucket=", "")
+		}
+		if strings.Contains(strings.ToLower(part), "endpoint=") {
+			s.Bucket.Endpoint = strings.ReplaceAll(part, "endpoint=", "")
+		}
+		if strings.Contains(strings.ToLower(part), "use_ssl=") {
+			s.Bucket.UseSSL = strings.ReplaceAll(part, "use_ssl=", "") == "true"
+		}
+		if strings.Contains(strings.ToLower(part), "ignore_cert=") {
+			s.Bucket.IgnoreCert = strings.ReplaceAll(part, "ignore_cert=", "") == "true"
+		}
+		if strings.Contains(strings.ToLower(part), "access_key=") {
+			s.Bucket.AccessKey = strings.ReplaceAll(part, "access_key=", "")
+		}
+		if strings.Contains(strings.ToLower(part), "secret_key=") {
+			s.Bucket.SecretKey = strings.ReplaceAll(part, "secret_key=", "")
+		}
+		if strings.Contains(strings.ToLower(part), "use_environment_authentication=") {
+			s.Bucket.UseEnvironmentAuthentication = strings.ReplaceAll(part, "use_environment_authentication=", "")
+		}
+	}
+	if provider == "" || !strings.EqualFold(provider, providerName) {
+		ctx.LogDebugf("Provider %s is not %s, skipping", providerName, provider)
+		return false, nil
+	}
+
+	if s.Bucket.Name == "" {
+		return false, fmt.Errorf("missing bucket name")
+	}
+	if s.Bucket.Endpoint == "" {
+		return false, fmt.Errorf("missing bucket endpoint")
+	}
+	if s.Bucket.AccessKey == "" {
+		return false, fmt.Errorf("missing bucket access key")
+	}
+	if s.Bucket.SecretKey == "" {
+		return false, fmt.Errorf("missing bucket secret key")
+	}
+
+	return true, nil
+}
+
+// uploadFile uploads a file to an S3 bucket
+func (s *MinioBucketProvider) PushFile(ctx basecontext.ApiContext, rootLocalPath string, path string, filename string) error {
+	ctx.LogInfof("Pushing file %s", filename)
+	localFilePath := filepath.Join(rootLocalPath, filename)
+	remoteFilePath := strings.TrimPrefix(filepath.Join(path, filename), "/")
+
+	// Create a new session using the default region and credentials.
+	var err error
+	session, err := s.createNewSession()
+	if err != nil {
+		return err
+	}
+
+	uploader := s3manager.NewUploader(session, func(u *s3manager.Uploader) {
+		u.PartSize = 10 * 1024 * 1024 // The minimum/default allowed part size is 5MB
+		u.Concurrency = 5
+	})
+
+	// Open the file for reading.
+	file, err := os.Open(filepath.Clean(localFilePath))
+	if err != nil {
+		return err
+	}
+
+	// Get the file info for size
+	fileInfo, err := file.Stat()
+	if err != nil {
+		ctx.LogInfof("ERROR:", err)
+		return err
+	}
+
+	defer file.Close()
+
+	cr := writers.NewProgressFileReader(file, fileInfo.Size())
+	cid := cr.CorrelationId()
+	cr.SetPrefix("Reading file parts")
+
+	_, err = uploader.Upload(&s3manager.UploadInput{
+		Bucket: aws.String(s.Bucket.Name),
+		Key:    aws.String(remoteFilePath),
+		Body:   cr,
+	})
+	if err != nil {
+		return err
+	}
+
+	ns := notifications.Get()
+	msg := fmt.Sprintf("Pushing file %s", filename)
+	ns.FinishProgress(cid, msg)
+	ns.NotifyInfo(fmt.Sprintf("Finished pushing file %s", filename))
+	return nil
+}
+
+func (s *MinioBucketProvider) PullFile(ctx basecontext.ApiContext, path string, filename string, destination string) error {
+	ctx.LogInfof("Pulling file %s", filename)
+	startTime := time.Now()
+	if s.FileNameChannel != nil {
+		s.FileNameChannel <- filename
+	}
+	remoteFilePath := strings.TrimPrefix(filepath.Join(path, filename), "/")
+	destinationFilePath := filepath.Join(destination, filename)
+
+	// Create a new session using the default region and credentials.
+	var err error
+	session, err := s.createNewSession()
+	if err != nil {
+		return err
+	}
+
+	headObjectOutput, err := s3.New(session).HeadObject(&s3.HeadObjectInput{
+		Bucket: aws.String(s.Bucket.Name),
+		Key:    aws.String(remoteFilePath),
+	})
+	if err != nil {
+		return err
+	}
+	fileSize := *headObjectOutput.ContentLength
+
+	downloader := s3manager.NewDownloader(session, func(d *s3manager.Downloader) {
+		d.PartSize = 10 * 1024 * 1024 // The minimum/default allowed part size is 5MB
+		d.Concurrency = 5             // default is 5
+	})
+
+	// Create a file to write the S3 Object contents to.
+	f, err := os.Create(filepath.Clean(destinationFilePath))
+	if err != nil {
+		return err
+	}
+
+	cw := writers.NewProgressWriter(f, fileSize)
+	cw.SetFilename(filename)
+	cw.SetPrefix("Pulling")
+	cid := cw.CorrelationId()
+	// Write the contents of S3 Object to the file
+	_, err = downloader.Download(cw, &s3.GetObjectInput{
+		Bucket: aws.String(s.Bucket.Name),
+		Key:    aws.String(remoteFilePath),
+	})
+	if err != nil {
+		return err
+	}
+
+	ns := notifications.Get()
+	msg := fmt.Sprintf("Pulling %s", filename)
+	ns.NotifyProgress(cid, msg, 100)
+	endTime := time.Now()
+	ns.NotifyInfo(fmt.Sprintf("Finished pulling and decompressing file %s, took %s", filename, endTime.Sub(startTime)))
+	return nil
+}
+
+func (s *MinioBucketProvider) PullFileAndDecompress(ctx basecontext.ApiContext, path, filename, destination string) error {
+	cfg := config.Get()
+	if cfg.IsCanaryEnabled() {
+		ctx.LogInfof("\rUsing Canary version of pullFileAndDecompress")
+		return s.pullFileAndDecompressUnstable(ctx, path, filename, destination)
+	}
+	return s.pullFileAndDecompressUnstable(ctx, path, filename, destination)
+}
+
+func (s *MinioBucketProvider) PullFileToMemory(ctx basecontext.ApiContext, path string, filename string) ([]byte, error) {
+	ctx.LogInfof("Pulling file %s", filename)
+	maxFileSize := 0.5 * 1024 * 1024 // 0.5MB
+
+	if s.FileNameChannel != nil {
+		s.FileNameChannel <- filename
+	}
+	remoteFilePath := strings.TrimPrefix(filepath.Join(path, filename), "/")
+
+	// Create a new session using the default region and credentials.
+	var err error
+	session, err := s.createNewSession()
+	if err != nil {
+		return nil, err
+	}
+
+	headObjectOutput, err := s3.New(session).HeadObject(&s3.HeadObjectInput{
+		Bucket: aws.String(s.Bucket.Name),
+		Key:    aws.String(remoteFilePath),
+	})
+	if err != nil {
+		return nil, err
+	}
+	fileSize := *headObjectOutput.ContentLength
+
+	if fileSize > int64(maxFileSize) {
+		return nil, fmt.Errorf("file size is too large to pull to memory")
+	}
+
+	downloader := s3manager.NewDownloader(session, func(d *s3manager.Downloader) {
+		d.PartSize = 10 * 1024 * 1024 // The minimum/default allowed part size is 5MB
+		d.Concurrency = 5             // default is 5
+	})
+
+	cw := writers.NewByteSliceWriterAt(fileSize)
+
+	// Write the contents of S3 Object to the file
+	_, err = downloader.Download(cw, &s3.GetObjectInput{
+		Bucket: aws.String(s.Bucket.Name),
+		Key:    aws.String(remoteFilePath),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return cw.Bytes(), nil
+}
+
+func (s *MinioBucketProvider) DeleteFile(ctx basecontext.ApiContext, path string, fileName string) error {
+	remoteFilePath := strings.TrimPrefix(filepath.Join(path, fileName), "/")
+
+	// Create a new AWS session
+	session, err := s.createNewSession()
+	if err != nil {
+		return err
+	}
+
+	// Create a new S3 client
+	svc := s3.New(session)
+
+	_, err = svc.DeleteObject(&s3.DeleteObjectInput{
+		Bucket: aws.String(s.Bucket.Name),
+		Key:    aws.String(remoteFilePath),
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *MinioBucketProvider) FileChecksum(ctx basecontext.ApiContext, path string, fileName string) (string, error) {
+	// Create a new AWS session
+	session, err := s.createNewSession()
+	if err != nil {
+		return "", err
+	}
+
+	// Create a new S3 client
+	svc := s3.New(session)
+
+	fullPath := filepath.Join(path, fileName)
+	resp, err := svc.HeadObject(&s3.HeadObjectInput{
+		Bucket: aws.String(s.Bucket.Name),
+		Key:    aws.String(fullPath),
+	})
+	if err != nil {
+		return "", err
+	}
+
+	// The ETag is enclosed in double quotes, so we remove them
+	checksum := strings.Trim(*resp.ETag, "\"")
+
+	return checksum, nil
+}
+
+func (s *MinioBucketProvider) FileExists(ctx basecontext.ApiContext, path string, fileName string) (bool, error) {
+	fullPath := filepath.Join(path, fileName)
+	// Create a new AWS session
+	session, err := s.createNewSession()
+	if err != nil {
+		return false, err
+	}
+
+	// Create a new S3 client
+	svc := s3.New(session)
+
+	// Check if the file exists
+	_, err = svc.HeadObject(&s3.HeadObjectInput{
+		Bucket: aws.String(s.Bucket.Name),
+		Key:    aws.String(fullPath),
+	})
+	if err != nil {
+		if strings.Contains(err.Error(), "NotFound") {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return true, nil
+}
+
+func (s *MinioBucketProvider) CreateFolder(ctx basecontext.ApiContext, folderPath string, folderName string) error {
+	fullPath := filepath.Join(folderPath, folderName)
+	// Create a new session using the default region and credentials.
+	var err error
+	// Create a new AWS session
+	session, err := s.createNewSession()
+	if err != nil {
+		return err
+	}
+
+	uploader := s3manager.NewUploader(session, func(u *s3manager.Uploader) {
+		u.PartSize = 10 * 1024 * 1024 // The minimum/default allowed part size is 5MB
+		u.Concurrency = 5             // default is 5
+	})
+
+	if !strings.HasSuffix(fullPath, "/") {
+		fullPath = fullPath + "/"
+	}
+
+	exists, err := s.FolderExists(ctx, folderPath, folderName)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+
+	_, err = uploader.Upload(&s3manager.UploadInput{
+		Bucket: aws.String(s.Bucket.Name),
+		Key:    aws.String(fullPath),
+		Body:   bytes.NewReader([]byte{}),
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *MinioBucketProvider) DeleteFolder(ctx basecontext.ApiContext, folderPath string, folderName string) error {
+	fullPath := filepath.Join(folderPath, folderName)
+	fullPath = strings.TrimPrefix(fullPath, "/")
+	// Create a new AWS session
+	session, err := s.createNewSession()
+	if err != nil {
+		return err
+	}
+
+	// Create a new S3 client
+	svc := s3.New(session)
+
+	resp, err := svc.ListObjectsV2(&s3.ListObjectsV2Input{
+		Bucket: aws.String(s.Bucket.Name),
+		Prefix: aws.String(fullPath),
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, obj := range resp.Contents {
+		_, err := svc.DeleteObject(&s3.DeleteObjectInput{
+			Bucket: aws.String(s.Bucket.Name),
+			Key:    obj.Key,
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (s *MinioBucketProvider) FolderExists(ctx basecontext.ApiContext, folderPath string, folderName string) (bool, error) {
+	fullPath := filepath.Join(folderPath, folderName)
+	fullPath = strings.TrimPrefix(fullPath, "/")
+
+	// Create a new AWS session
+	session, err := s.createNewSession()
+	if err != nil {
+		return false, err
+	}
+
+	// Create a new S3 client
+	svc := s3.New(session)
+
+	// Check if the folder exists
+	resp, err := svc.ListObjectsV2(&s3.ListObjectsV2Input{
+		Bucket:    aws.String(s.Bucket.Name),
+		Prefix:    aws.String(fullPath),
+		Delimiter: aws.String("/"),
+		MaxKeys:   aws.Int64(1),
+	})
+	if err != nil {
+		return false, err
+	}
+
+	// If the folder exists, return true
+	if len(resp.CommonPrefixes) > 0 {
+		return true, nil
+	}
+
+	// If the folder does not exist, return false
+	return false, nil
+}
+
+func (s *MinioBucketProvider) FileSize(ctx basecontext.ApiContext, path string, filename string) (int64, error) {
+	ctx.LogInfof("Checking file %s size", filename)
+	remoteFilePath := strings.TrimPrefix(filepath.Join(path, filename), "/")
+
+	// Create a new session using the default region and credentials.
+	var err error
+	session, err := s.createNewSession()
+	if err != nil {
+		return -1, err
+	}
+
+	headObjectOutput, err := s3.New(session).HeadObject(&s3.HeadObjectInput{
+		Bucket: aws.String(s.Bucket.Name),
+		Key:    aws.String(remoteFilePath),
+	})
+	if err != nil {
+		return -1, err
+	}
+	fileSize := *headObjectOutput.ContentLength
+
+	return fileSize, nil
+}
+
+func (s *MinioBucketProvider) createNewSession() (*session.Session, error) {
+	// Create a new session using the default region and credentials.
+	var creds *credentials.Credentials
+	var err error
+
+	if s.Bucket.UseEnvironmentAuthentication == "true" {
+		creds = credentials.NewEnvCredentials()
+	} else {
+		creds = credentials.NewStaticCredentials(s.Bucket.AccessKey, s.Bucket.SecretKey, "")
+	}
+
+	cfg := s.generateNewCfg()
+	cfg.Credentials = creds
+	cfg.MaxRetries = aws.Int(10)
+	cfg.Region = aws.String("us-east-1")
+
+	session := session.Must(session.NewSession(cfg))
+
+	return session, err
+}
+
+func (s *MinioBucketProvider) generateNewCfg() *aws.Config {
+	endpoint := s.Bucket.Endpoint
+	if strings.HasPrefix(endpoint, "http://") || strings.HasPrefix(endpoint, "https://") {
+		endpoint = strings.TrimPrefix(endpoint, "http://")
+		endpoint = strings.TrimPrefix(endpoint, "https://")
+	}
+	if s.Bucket.UseSSL {
+		endpoint = "https://" + endpoint
+	} else {
+		endpoint = "http://" + endpoint
+	}
+
+	cfg := aws.NewConfig().
+		WithEndpoint(endpoint).
+		WithS3ForcePathStyle(true).
+		WithDisableSSL(s.Bucket.UseSSL).
+		WithHTTPClient(&http.Client{
+			Timeout: 0,
+			Transport: &http.Transport{
+				IdleConnTimeout:       120 * time.Minute,
+				TLSHandshakeTimeout:   30 * time.Second,
+				ExpectContinueTimeout: 120 * time.Minute,
+				ResponseHeaderTimeout: 120 * time.Minute,
+				DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+					d := net.Dialer{
+						Timeout:   30 * time.Second,
+						KeepAlive: 30 * time.Second,
+					}
+					conn, err := d.DialContext(ctx, network, addr)
+					return conn, err
+				},
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: s.Bucket.IgnoreCert,
+				},
+			},
+		})
+
+	return cfg
+}
+
+func (s *MinioBucketProvider) pullFileAndDecompressStable(ctx basecontext.ApiContext, path, filename, destination string) error {
+	ctx.LogInfof("Pulling file %s", filename)
+	startTime := time.Now()
+	remoteFilePath := strings.TrimPrefix(filepath.Join(path, filename), "/")
+	ns := notifications.Get()
+
+	session, err := s.createNewSession()
+	if err != nil {
+		return err
+	}
+	svc := s3.New(session)
+
+	// Getting the total size (for progress notifications)
+	headObjectOutput, err := svc.HeadObject(&s3.HeadObjectInput{
+		Bucket: aws.String(s.Bucket.Name),
+		Key:    aws.String(remoteFilePath),
+	})
+	if err != nil {
+		return fmt.Errorf("failed HeadObject: %w", err)
+	}
+	totalSize := *headObjectOutput.ContentLength
+
+	// Setting up the chunked download and decompression
+	const chunkSize int64 = 100 * 1024 * 1024 // 500MB chunk size
+	var start int64 = 0
+	var totalDownloaded int64 = 0
+	msgPrefix := fmt.Sprintf("Pulling %s", filename)
+	cid := helpers.GenerateId()
+
+	r, w := io.Pipe()
+	chunkFilesChan := make(chan string, 4)
+
+	// Setting up an errgroup to run all goroutines and capture errors
+	ctxBck := context.Background()
+	ctxChunk, cancel := context.WithTimeout(ctxBck, 5*time.Hour)
+	group, groupCtx := errgroup.WithContext(ctxChunk)
+	defer cancel()
+
+	// Download goroutine: download chunks into temp files and send their paths over channel
+	group.Go(func() error {
+		defer close(chunkFilesChan) // Signal no more chunks
+
+		buf := make([]byte, 8*1024*1024) // 2MB buffer for reading from S3
+
+		for start < totalSize {
+			// Honor cancellations
+			select {
+			case <-groupCtx.Done():
+				return groupCtx.Err()
+			default:
+			}
+
+			end := start + chunkSize - 1
+			if end >= totalSize {
+				end = totalSize - 1
+			}
+			rangeHeader := fmt.Sprintf("bytes=%d-%d", start, end)
+
+			// Get one chunk from S3
+			resp, err := svc.GetObjectWithContext(groupCtx, &s3.GetObjectInput{
+				Bucket: aws.String(s.Bucket.Name),
+				Key:    aws.String(remoteFilePath),
+				Range:  aws.String(rangeHeader),
+			})
+			if err != nil {
+				return fmt.Errorf("failed to get S3 range %s: %w", rangeHeader, err)
+			}
+
+			// Create a temporary file for this chunk
+			tmpFile, err := os.CreateTemp("", "s3_chunk_")
+			if err != nil {
+				resp.Body.Close()
+				return fmt.Errorf("failed to create temp file: %w", err)
+			}
+
+			// Copy the chunk from S3 response to the temp file
+			var chunkDownloaded int64
+			for {
+				n, readErr := resp.Body.Read(buf)
+				if n > 0 {
+					if _, writeErr := tmpFile.Write(buf[:n]); writeErr != nil {
+						tmpFile.Close()
+						os.Remove(tmpFile.Name())
+						resp.Body.Close()
+						return fmt.Errorf("failed to write chunk to temp file: %w", writeErr)
+					}
+					chunkDownloaded += int64(n)
+					atomic.AddInt64(&totalDownloaded, int64(n))
+
+					// Send a progress notification
+					if ns != nil && totalSize > 0 {
+						percent := float64(float64(totalDownloaded)/float64(totalSize)) * 100 * 10
+						msg := notifications.
+							NewProgressNotificationMessage(cid, msgPrefix, percent).
+							SetCurrentSize(totalDownloaded).
+							SetTotalSize(totalSize).
+							SetStartingTime(startTime)
+						ns.Notify(msg)
+					}
+				}
+				if readErr != nil {
+					resp.Body.Close()
+					if readErr != io.EOF {
+						// Real error
+						tmpFile.Close()
+						os.Remove(tmpFile.Name())
+						return fmt.Errorf("failed reading from S3 chunk: %w", readErr)
+					}
+					// readErr == io.EOF => done with this chunk
+					break
+				}
+			}
+
+			// Reset temp file offset to the beginning, close the S3 response
+			if _, err := tmpFile.Seek(0, io.SeekStart); err != nil {
+				tmpFile.Close()
+				os.Remove(tmpFile.Name())
+				return fmt.Errorf("failed to seek in temp file: %w", err)
+			}
+			resp.Body.Close()
+
+			// Send temp file name to the streamer
+			tmpFileName := tmpFile.Name()
+			tmpFile.Close() // Let streamer reopen it
+			chunkFilesChan <- tmpFileName
+
+			// Move to the next chunk
+			start = end + 1
+		}
+		return nil // done successfully
+	})
+
+	// Streamer goroutine: read chunk file paths, stream them to the decompressor, and clean up
+	group.Go(func() error {
+		defer w.Close() // signal EOF to the decompressor
+
+		for chunkFileName := range chunkFilesChan {
+			// Honor cancellations
+			select {
+			case <-groupCtx.Done():
+				return groupCtx.Err()
+			default:
+			}
+
+			chunkFile, err := os.Open(chunkFileName)
+			if err != nil {
+				return fmt.Errorf("failed to open temp chunk file: %w", err)
+			}
+
+			// Stream the chunk into the decompressor pipe
+			if _, copyErr := io.Copy(w, chunkFile); copyErr != nil {
+				chunkFile.Close()
+				os.Remove(chunkFileName)
+				return fmt.Errorf("failed to copy chunk to pipe: %w", copyErr)
+			}
+			chunkFile.Close()
+			os.Remove(chunkFileName) // clean up
+		}
+		return nil
+	})
+
+	// Decompressor goroutine: decompress from the pipe to the destination
+	group.Go(func() error {
+		// Decompress from the read-end of the pipe
+		decompressErr := compressor.DecompressFromReader(ctx, r, destination)
+		if decompressErr != nil {
+			// If decompression fails, close the pipe with error (so streamer sees it)
+			_ = w.CloseWithError(decompressErr)
+			return fmt.Errorf("decompression failed: %w", decompressErr)
+		}
+		return nil
+	})
+
+	// Wait for all goroutines to finish and check for errors
+	if err := group.Wait(); err != nil {
+		return err
+	}
+
+	// Everything finished successfully send a final progress notification
+	finalMsg := fmt.Sprintf("Pulling %s", filename)
+	ns.NotifyProgress(cid, finalMsg, 100)
+	ns.NotifyInfo(fmt.Sprintf("Finished pulling and decompressing file %s, took %v",
+		filename, time.Since(startTime)))
+
+	return nil
+}
+
+func (s *MinioBucketProvider) pullFileAndDecompressUnstable(ctx basecontext.ApiContext, path, filename, destination string) error {
+	// Create S3 session
+	session, err := s.createNewSession()
+	if err != nil {
+		return fmt.Errorf("failed to create S3 session: %w", err)
+	}
+	svc := s3.New(session)
+
+	// Create the chunk downloader
+	downloader := NewMinioChunkDownloader(s.Bucket.Name, path, svc)
+
+	// Create the chunk manager service with default worker and chunk settings
+	chunkManager := chunkmanagerservice.NewChunkManagerService(
+		downloader,
+		6,  // workerCount
+		40, // maxChunksOnDisk
+	)
+
+	// Create the download request
+	request := chunkmanagerservice.DownloadRequest{
+		Path:                path,
+		Filename:            filename,
+		Destination:         destination,
+		ChunkSize:           100 * 1024 * 1024, // 100MB chunks
+		NotificationService: notifications.Get(),
+		MessagePrefix:       fmt.Sprintf("[Unstable] Pulling %s", filename),
+		CorrelationID:       helpers.GenerateId(),
+	}
+
+	// Execute the download and decompress operation
+	return chunkManager.DownloadAndDecompress(ctx, request)
+}

--- a/src/tests/catalog_provider_push.go
+++ b/src/tests/catalog_provider_push.go
@@ -57,5 +57,18 @@ func TestCatalogProvidersPushFile(ctx basecontext.ApiContext, filePath string, t
 		}
 	}
 
+	if cfg.GetKey("MINIO_TEST_CONNECTION") != "" {
+		ctx.LogInfof("Testing %v", cfg.GetKey("MINIO_TEST_CONNECTION"))
+		ctx.LogInfof("Testing connection to Minio")
+		test := tester.NewTestProvider(ctx, cfg.GetKey("MINIO_TEST_CONNECTION"))
+		err := test.PushFileToProvider(filePath, targetPath, targetFilename)
+		if err != nil {
+			ctx.LogErrorf(err.Error())
+			return err
+		} else {
+			ctx.LogInfof("Connection to Minio successful")
+		}
+	}
+
 	return nil
 }

--- a/src/tests/catalog_provider_testing.go
+++ b/src/tests/catalog_provider_testing.go
@@ -46,5 +46,18 @@ func TestCatalogProviders(ctx basecontext.ApiContext) error {
 		}
 	}
 
+	if cfg.GetKey("MINIO_TEST_CONNECTION") != "" {
+		ctx.LogInfof("Testing %v", cfg.GetKey("MINIO_TEST_CONNECTION"))
+		ctx.LogInfof("Testing connection to Minio")
+		test := tester.NewTestProvider(ctx, cfg.GetKey("MINIO_TEST_CONNECTION"))
+		err := test.Test()
+		if err != nil {
+			ctx.LogErrorf(err.Error())
+			return err
+		} else {
+			ctx.LogInfof("Connection to Minio successful")
+		}
+	}
+
 	return nil
 }


### PR DESCRIPTION
# Description

- Added a new catalog storage provider for the MinIO an example of a connection string would be (provider=minio;endpoint=http://1localhost:9000;bucket=example;access_key=minioadmin;secret_key=something_secret;use_ssl=false;ignore_cert=true)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

### Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md file accordingly
