### PR TITLE
fix issue with VM desync

### DIFF
--- a/src/catalog/pull.go
+++ b/src/catalog/pull.go
@@ -322,7 +322,7 @@ func (s *CatalogManifestService) renameMachineWithParallelsDesktop(r *models.Pul
 	if !response.HasErrors() {
 		s.ns.NotifyInfof("Renaming machine %v to %v", r.MachineName, r.MachineName)
 		filter := fmt.Sprintf("name=%s", r.MachineName)
-		vms, err := parallelsDesktopSvc.GetCachedVms(s.ctx, filter)
+		vms, err := parallelsDesktopSvc.GetVms(s.ctx, filter)
 		if err != nil {
 			s.ns.NotifyErrorf("Error getting machine %v: %v", r.MachineName, err)
 			response.AddError(err)
@@ -380,7 +380,7 @@ func (s *CatalogManifestService) startMachineWithParallelsDesktop(r *models.Pull
 
 	if !response.HasErrors() {
 		filter := fmt.Sprintf("name=%s", r.MachineName)
-		vms, err := parallelsDesktopSvc.GetCachedVms(s.ctx, filter)
+		vms, err := parallelsDesktopSvc.GetVms(s.ctx, filter)
 		if err != nil {
 			s.ns.NotifyErrorf("Error getting machine %v: %v", r.MachineName, err)
 			response.AddError(err)

--- a/src/serviceprovider/parallelsdesktop/helpers.go
+++ b/src/serviceprovider/parallelsdesktop/helpers.go
@@ -7,8 +7,14 @@ import (
 	"github.com/Parallels/prl-devops-service/models"
 )
 
-func (s *ParallelsService) findVm(ctx basecontext.ApiContext, idOrName string) (*models.ParallelsVM, error) {
-	vms, err := s.GetCachedVms(ctx, "")
+func (s *ParallelsService) findVm(ctx basecontext.ApiContext, idOrName string, cached bool) (*models.ParallelsVM, error) {
+	var err error
+	var vms []models.ParallelsVM
+	if cached {
+		vms, err = s.GetCachedVms(ctx, "")
+	} else {
+		vms, err = s.GetVms(ctx, "")
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -22,8 +28,15 @@ func (s *ParallelsService) findVm(ctx basecontext.ApiContext, idOrName string) (
 	return nil, ErrVirtualMachineNotFound
 }
 
-func (s *ParallelsService) findVmSync(ctx basecontext.ApiContext, idOrName string) (*models.ParallelsVM, error) {
-	vms, err := s.GetCachedVms(ctx, "")
+func (s *ParallelsService) findVmSync(ctx basecontext.ApiContext, idOrName string, cached bool) (*models.ParallelsVM, error) {
+	var err error
+	var vms []models.ParallelsVM
+	if cached {
+		vms, err = s.GetCachedVms(ctx, "")
+	} else {
+		vms, err = s.GetVms(ctx, "")
+	}
+
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Description

After the new event emitter we had a racing condition during the catalog pull process where after registering we would check immediately the presence of a VM but this would not be there due to the event not being fired on time

- Added a new function to get VMs that gets it sync
- Updated dependencies on the cache function to this method

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if any)
- [x] My changes generate no new warnings
- [x] I have run tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md file accordingly
