### PR TITLE
feat: Add real-time orchestrator event broadcasting for host health and VM state updates

### DIFF
--- a/src/constants/event_emitter.go
+++ b/src/constants/event_emitter.go
@@ -7,12 +7,13 @@ type EventType string
 // Event Message Types - predefined types for event routing
 // Clients subscribe to these types and receive messages of that type
 const (
-	EventTypeGlobal EventType = "global" // Broadcasts to all subscribers
-	EventTypeSystem EventType = "system" // System-level events
-	EventTypeVM     EventType = "vm"     // Virtual machine events
-	EventTypeHost   EventType = "host"   // Host-level events
-	EventTypePDFM   EventType = "pdfm"   // PDFM-specific events
-	EventTypeHealth EventType = "health" // Health check events
+	EventTypeGlobal       EventType = "global"       // Broadcasts to all subscribers
+	EventTypeSystem       EventType = "system"       // System-level events
+	EventTypeVM           EventType = "vm"           // Virtual machine events
+	EventTypeHost         EventType = "host"         // Host-level events
+	EventTypePDFM         EventType = "pdfm"         // PDFM-specific events
+	EventTypeHealth       EventType = "health"       // Health check events
+	EventTypeOrchestrator EventType = "orchestrator" // Orchestrator events
 )
 
 func (e EventType) String() string {
@@ -22,7 +23,7 @@ func (e EventType) String() string {
 // IsValid checks if the EventType is valid
 func (e EventType) IsValid() bool {
 	switch e {
-	case EventTypeGlobal, EventTypeSystem, EventTypeVM, EventTypeHost, EventTypePDFM, EventTypeHealth:
+	case EventTypeGlobal, EventTypeSystem, EventTypeVM, EventTypeHost, EventTypePDFM, EventTypeHealth, EventTypeOrchestrator:
 		return true
 	default:
 		return false
@@ -38,5 +39,6 @@ func GetAllEventTypes() []EventType {
 		EventTypeHost,
 		EventTypePDFM,
 		EventTypeHealth,
+		EventTypeOrchestrator,
 	}
 }

--- a/src/models/event_message.go
+++ b/src/models/event_message.go
@@ -77,3 +77,13 @@ type VmAdded struct {
 type VmRemoved struct {
 	VmID string `json:"vm_id"`
 }
+
+type HostHealthUpdate struct {
+	HostID string `json:"host_id"`
+	State  string `json:"state"`
+}
+
+type HostVmEvent struct {
+	HostID string      `json:"host_id"`
+	Event  interface{} `json:"event"` // VmStateChange, VmAdded, or VmRemoved
+}

--- a/src/orchestrator/handlers/pdfm_event_handler.go
+++ b/src/orchestrator/handlers/pdfm_event_handler.go
@@ -108,6 +108,19 @@ func (h *PDfMEventHandler) handleVmStateChange(ctx basecontext.ApiContext, hostI
 		ctx.LogErrorf("[PDfMEventHandler] Error updating VM %s state in DB: %v", stateChange.VmID, err)
 	} else {
 		ctx.LogInfof("[PDfMEventHandler] Updated VM %s state to %s", stateChange.VmID, stateChange.CurrentState)
+
+		// Emit VM state change event
+		if emitter := serviceprovider.GetEventEmitter(); emitter != nil && emitter.IsRunning() {
+			msg := models.NewEventMessage(constants.EventTypeOrchestrator, "HOST_VM_STATE_CHANGED", models.HostVmEvent{
+				HostID: hostID,
+				Event:  stateChange,
+			})
+			go func() {
+				if err := emitter.Broadcast(msg); err != nil {
+					ctx.LogErrorf("[PDfMEventHandler] Failed to broadcast event HOST_VM_STATE_CHANGED: %v", err)
+				}
+			}()
+		}
 	}
 }
 
@@ -156,6 +169,19 @@ func (h *PDfMEventHandler) handleVmAdded(ctx basecontext.ApiContext, hostID stri
 		ctx.LogErrorf("[PDfMEventHandler] Error updating VM %s state in DB: %v", vmAdded.VmID, err)
 	} else {
 		ctx.LogInfof("[PDfMEventHandler] VM added %s", vmAdded.VmID)
+
+		// Emit VM added event
+		if emitter := serviceprovider.GetEventEmitter(); emitter != nil && emitter.IsRunning() {
+			msg := models.NewEventMessage(constants.EventTypeOrchestrator, "HOST_VM_ADDED", models.HostVmEvent{
+				HostID: hostID,
+				Event:  vmAdded,
+			})
+			go func() {
+				if err := emitter.Broadcast(msg); err != nil {
+					ctx.LogErrorf("[PDfMEventHandler] Failed to broadcast event HOST_VM_ADDED: %v", err)
+				}
+			}()
+		}
 	}
 }
 
@@ -205,5 +231,18 @@ func (h *PDfMEventHandler) handleVmRemoved(ctx basecontext.ApiContext, hostID st
 		ctx.LogErrorf("[PDfMEventHandler] Error updating VM %s state in DB: %v", vmRemoved.VmID, err)
 	} else {
 		ctx.LogInfof("[PDfMEventHandler] Removed VM %s", vmRemoved.VmID)
+
+		// Emit VM removed event
+		if emitter := serviceprovider.GetEventEmitter(); emitter != nil && emitter.IsRunning() {
+			msg := models.NewEventMessage(constants.EventTypeOrchestrator, "HOST_VM_REMOVED", models.HostVmEvent{
+				HostID: hostID,
+				Event:  vmRemoved,
+			})
+			go func() {
+				if err := emitter.Broadcast(msg); err != nil {
+					ctx.LogErrorf("[PDfMEventHandler] Failed to broadcast event HOST_VM_REMOVED: %v", err)
+				}
+			}()
+		}
 	}
 }

--- a/src/serviceprovider/eventEmitter/main.go
+++ b/src/serviceprovider/eventEmitter/main.go
@@ -153,6 +153,18 @@ func (e *EventEmitter) RegisterHandler(eventType []constants.EventType, handler 
 	}
 }
 
+// Broadcast sends a message to all subscribers of the event type
+func (e *EventEmitter) Broadcast(message *models.EventMessage) error {
+	if atomic.LoadInt32(&e.isRunning) == 0 {
+		e.ctx.LogWarnf("[EventEmitter] Event emitter is not running, skipping broadcast of message %s", message.ID)
+		return errors.New("event emitter is not running")
+	}
+	if e.hub != nil {
+		return e.hub.broadcastMessage(message)
+	}
+	return errors.New("hub is not initialized")
+}
+
 // Shutdown stops the event emitter service
 func (e *EventEmitter) Shutdown() {
 	if atomic.LoadInt32(&e.isRunning) == 0 {

--- a/src/serviceprovider/eventEmitter/main_test.go
+++ b/src/serviceprovider/eventEmitter/main_test.go
@@ -385,3 +385,55 @@ func TestUnregisterClientCmd_Execute(t *testing.T) {
 
 	assert.NotContains(t, hub.clients, "test-client")
 }
+
+func TestEventEmitter_Broadcast_Success(t *testing.T) {
+	// Reset singleton
+	globalEventEmitter = nil
+	once = sync.Once{}
+
+	ctx := basecontext.NewBaseContext()
+	emitter := NewEventEmitter(ctx)
+
+	// Manually initialize hub for testing
+	emitter.hub = &Hub{
+		ctx:           ctx,
+		clients:       make(map[string]*Client),
+		subscriptions: make(map[constants.EventType]map[string]bool),
+	}
+	emitter.isRunning = 1
+
+	msg := models.NewEventMessage(constants.EventTypeVM, "test", nil)
+	err := emitter.Broadcast(msg)
+	assert.NoError(t, err)
+}
+
+func TestEventEmitter_Broadcast_NotRunning(t *testing.T) {
+	// Reset singleton
+	globalEventEmitter = nil
+	once = sync.Once{}
+
+	ctx := basecontext.NewBaseContext()
+	emitter := NewEventEmitter(ctx)
+	// Not setting isRunning to 1
+
+	msg := models.NewEventMessage(constants.EventTypeVM, "test", nil)
+	err := emitter.Broadcast(msg)
+	assert.Error(t, err)
+	assert.Equal(t, "event emitter is not running", err.Error())
+}
+
+func TestEventEmitter_Broadcast_HubNotInitialized(t *testing.T) {
+	// Reset singleton
+	globalEventEmitter = nil
+	once = sync.Once{}
+
+	ctx := basecontext.NewBaseContext()
+	emitter := NewEventEmitter(ctx)
+	emitter.isRunning = 1
+	// Hub is nil
+
+	msg := models.NewEventMessage(constants.EventTypeVM, "test", nil)
+	err := emitter.Broadcast(msg)
+	assert.Error(t, err)
+	assert.Equal(t, "hub is not initialized", err.Error())
+}

--- a/src/serviceprovider/event_emitter.go
+++ b/src/serviceprovider/event_emitter.go
@@ -1,0 +1,9 @@
+package serviceprovider
+
+import (
+	eventemitter "github.com/Parallels/prl-devops-service/serviceprovider/eventEmitter"
+)
+
+func GetEventEmitter() *eventemitter.EventEmitter {
+	return eventemitter.Get()
+}


### PR DESCRIPTION
# Description

- New Event Type: orchestrator - Subscribe via /v1/ws/subscribe?event_types=orchestrator
- Real-time Host Health Updates: Receive notifications when orchestrator checks host health
- Real-time VM State Updates: Get instant notifications for VM lifecycle events across all managed hosts

closes #321 

## Type of change
- [x] New feature (non-breaking change which adds functionality)


### Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md file accordingly
