### PR TITLE
Fix issue when clone vm name has spaces

### DIFF
--- a/src/models/virtual_machine_clone.go
+++ b/src/models/virtual_machine_clone.go
@@ -3,7 +3,8 @@ package models
 import "github.com/Parallels/prl-devops-service/errors"
 
 type VirtualMachineCloneCommandRequest struct {
-	CloneName string `json:"clone_name"`
+	CloneName       string `json:"clone_name"`
+	DestinationPath string `json:"destination_path,omitempty"`
 }
 
 func (r *VirtualMachineCloneCommandRequest) Validate() error {

--- a/src/serviceprovider/parallelsdesktop/main.go
+++ b/src/serviceprovider/parallelsdesktop/main.go
@@ -1478,7 +1478,7 @@ func (s *ParallelsService) SetVmMachineOperation(ctx basecontext.ApiContext, vm 
 	case "clone":
 		cmd.Args = append(cmd.Args, s.executable, "clone", vm.ID)
 		if op.Value != "" {
-			cmd.Args = append(cmd.Args, "--name", op.Value)
+			cmd.Args = append(cmd.Args, "--name", fmt.Sprintf("\"%s\"", op.Value))
 		}
 		cmd.Args = append(cmd.Args, op.GetCmdArgs()...)
 	case "archive":
@@ -1500,7 +1500,7 @@ func (s *ParallelsService) SetVmMachineOperation(ctx basecontext.ApiContext, vm 
 	case "install-tools":
 		cmd.Args = append(cmd.Args, s.executable, "install-tools", vm.ID)
 	case "rename":
-		cmd.Args = append(cmd.Args, s.executable, "set", vm.ID, "--name", op.Value)
+		cmd.Args = append(cmd.Args, s.executable, "set", vm.ID, "--name", fmt.Sprintf("\"%s\"", op.Value))
 	default:
 		return errors.ErrConfigInvalidOperation(op.Operation)
 	}


### PR DESCRIPTION
# Description

- Added the missing property for the path where we want to clone
- Fixed an issue where operations would fail if there was spaces in the vm name

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


### Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md file accordingly
