### PR TITLE
fix(machines): update PauseVirtualMachineHandler to call PauseVm instead of ResetVm

### DIFF
--- a/src/controllers/machines.go
+++ b/src/controllers/machines.go
@@ -537,7 +537,7 @@ func PauseVirtualMachineHandler() restapi.ControllerHandler {
 		params := mux.Vars(r)
 		id := params["id"]
 
-		err := svc.ResetVm(ctx, id)
+		err := svc.PauseVm(ctx, id)
 		if err != nil {
 			ReturnApiError(ctx, w, models.NewFromError(err))
 			return


### PR DESCRIPTION
# Description
- Fixed /v1/machines/{id}/pause endtpoint that resting VM, insted of pausing VM.

- [X] Bug fix (non-breaking change which fixes an issue)


### Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md file accordingly
