### PR TITLE
Performing a folder access test while initialising and performing a PULL operation 

### DIFF
--- a/src/controllers/machines.go
+++ b/src/controllers/machines.go
@@ -1361,6 +1361,11 @@ func createCatalogMachine(ctx basecontext.ApiContext, request models.CreateVirtu
 	if err := pullRequest.Validate(); err != nil {
 		return nil, err
 	}
+	err := serviceprovider.TestCacheFolderAccess(ctx)
+	if err != nil {
+		ctx.LogErrorf("Cache folder access test failed: %v", err)
+		return nil, err
+	}
 
 	manifest := catalog.NewManifestService(ctx)
 	resultManifest := manifest.Pull(&pullRequest)

--- a/src/serviceprovider/helper.go
+++ b/src/serviceprovider/helper.go
@@ -1,0 +1,41 @@
+package serviceprovider
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/Parallels/prl-devops-service/basecontext"
+	"github.com/Parallels/prl-devops-service/config"
+	"github.com/Parallels/prl-devops-service/helpers"
+)
+
+func TestCacheFolderAccess(ctx basecontext.ApiContext) error {
+	cfg := config.Get()
+	if !cfg.IsApi() {
+		ctx.LogInfof("Not in API mode, skipping cache folder access test")
+		return nil
+	}
+	cacheFolder, err := cfg.CatalogCacheFolder()
+	if err != nil {
+		return err
+	}
+	touchCommand := helpers.Command{
+		Command: "touch",
+		Args:    []string{filepath.Join(cacheFolder, "test_cache_access.txt")},
+	}
+	_, stderr, exitCode, err := helpers.ExecuteWithOutput(context.Background(), touchCommand, time.Second*1)
+	if err != nil || exitCode != 0 {
+		return fmt.Errorf("Error creating test file in cache folder: %v, stderr: %s", err, stderr)
+	}
+	removeCommand := helpers.Command{
+		Command: "rm",
+		Args:    []string{filepath.Join(cacheFolder, "test_cache_access.txt")},
+	}
+	_, stderr, exitCode, err = helpers.ExecuteWithOutput(context.Background(), removeCommand, time.Second*1)
+	if err != nil || exitCode != 0 {
+		return fmt.Errorf("Error removing test file in cache folder: %v, stderr: %s ", err, stderr)
+	}
+	return nil
+}

--- a/src/serviceprovider/parallelsdesktop/helpers.go
+++ b/src/serviceprovider/parallelsdesktop/helpers.go
@@ -28,6 +28,14 @@ func (s *ParallelsService) findVm(ctx basecontext.ApiContext, idOrName string, c
 	return nil, ErrVirtualMachineNotFound
 }
 
+func (s *ParallelsService) findVmInCacheAndSystem(ctx basecontext.ApiContext, idOrName string) (*models.ParallelsVM, error) {
+	vm, err := s.findVmSync(ctx, idOrName, true)
+	if err == nil {
+		return vm, nil
+	}
+	return s.findVmSync(ctx, idOrName, false)
+}
+
 func (s *ParallelsService) findVmSync(ctx basecontext.ApiContext, idOrName string, cached bool) (*models.ParallelsVM, error) {
 	var err error
 	var vms []models.ParallelsVM

--- a/src/serviceprovider/parallelsdesktop/main.go
+++ b/src/serviceprovider/parallelsdesktop/main.go
@@ -418,8 +418,8 @@ func (s *ParallelsService) startForForcedCacheRefresh(ctx basecontext.ApiContext
 		s.ctx.LogInfof("eventsProcessing is false, not starting forced cache refresh")
 		return
 	}
-  cfg := config.Get()
-  interval := cfg.ForceCacheRefreshInterval()
+	cfg := config.Get()
+	interval := cfg.ForceCacheRefreshInterval()
 	ctx.LogInfof("Starting forced cache refresh for Parallels VMs every %v", interval)
 	ticker := time.NewTicker(interval)
 	go func() {
@@ -995,7 +995,7 @@ func (s *ParallelsService) VmStatus(ctx basecontext.ApiContext, id string) (*mod
 
 func (s *ParallelsService) RegisterVm(ctx basecontext.ApiContext, r models.RegisterVirtualMachineRequest) error {
 	if r.Uuid != "" {
-		vm, err := s.findVmSync(ctx, r.Uuid, true)
+		vm, err := s.findVmInCacheAndSystem(ctx, r.Uuid)
 		if err != nil {
 			return err
 		}
@@ -1007,7 +1007,7 @@ func (s *ParallelsService) RegisterVm(ctx basecontext.ApiContext, r models.Regis
 	}
 
 	if r.MachineName != "" {
-		vm, err := s.findVmSync(ctx, r.MachineName, true)
+		vm, err := s.findVmInCacheAndSystem(ctx, r.MachineName)
 		if err != nil && errors.GetSystemErrorCode(err) != 404 {
 			return err
 		}


### PR DESCRIPTION
# Description

- Now we will be performing a folder access test while initialising and performing a PULL operation 
- Improved finding VM logic,  now we will search for VM in the cache and the system 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

### Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md file accordingly
