### PR TITLE
feat(parallels): Validating cache in PD service after registering/unregistering a VM

### DIFF
--- a/src/reverse_proxy/main.go
+++ b/src/reverse_proxy/main.go
@@ -252,7 +252,7 @@ func (rps *ReverseProxyService) LoadFromDb() error {
 		if len(hostCopy.HttpRoutes) > 0 {
 			for i, route := range hostCopy.HttpRoutes {
 				if route.TargetVmId != "" {
-					vm, err := prl_svc.GetVm(rps.api_ctx, route.TargetVmId)
+					vm, err := prl_svc.GetVmSync(rps.api_ctx, route.TargetVmId)
 					if err != nil || vm.InternalIpAddress == "" || vm.InternalIpAddress == "-" || vm.State != "running" {
 						e := ""
 						if err != nil {
@@ -279,7 +279,7 @@ func (rps *ReverseProxyService) LoadFromDb() error {
 			}
 		}
 		if hostCopy.TcpRoute != nil && hostCopy.TcpRoute.TargetVmId != "" {
-			vm, err := prl_svc.GetVm(rps.api_ctx, hostCopy.TcpRoute.TargetVmId)
+			vm, err := prl_svc.GetVmSync(rps.api_ctx, hostCopy.TcpRoute.TargetVmId)
 			if err != nil || vm.InternalIpAddress == "" || vm.InternalIpAddress == "-" || vm.State != "running" {
 				if err != nil {
 					rps.api_ctx.LogErrorf("Error getting vm %s for reverse proxy tcp route: %s", hostCopy.TcpRoute.TargetVmId, err)

--- a/src/serviceprovider/parallelsdesktop/errors.go
+++ b/src/serviceprovider/parallelsdesktop/errors.go
@@ -3,3 +3,4 @@ package parallelsdesktop
 import "github.com/Parallels/prl-devops-service/errors"
 
 var ErrVirtualMachineNotFound = errors.NewWithCode("Virtual machine not found", 404)
+var ErrVirtualMachineNotFoundInCache = errors.NewWithCode("Virtual machine not found in cache even after multiple attempts", 404)

--- a/src/serviceprovider/parallelsdesktop/helpers.go
+++ b/src/serviceprovider/parallelsdesktop/helpers.go
@@ -2,31 +2,11 @@ package parallelsdesktop
 
 import (
 	"strings"
+	"time"
 
 	"github.com/Parallels/prl-devops-service/basecontext"
 	"github.com/Parallels/prl-devops-service/models"
 )
-
-func (s *ParallelsService) findVm(ctx basecontext.ApiContext, idOrName string, cached bool) (*models.ParallelsVM, error) {
-	var err error
-	var vms []models.ParallelsVM
-	if cached {
-		vms, err = s.GetCachedVms(ctx, "")
-	} else {
-		vms, err = s.GetVms(ctx, "")
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	for _, vm := range vms {
-		if strings.EqualFold(vm.Name, idOrName) || strings.EqualFold(vm.ID, idOrName) {
-			return &vm, nil
-		}
-	}
-	ctx.LogInfof("VM with name or id %v not found with cached=%v", idOrName, cached)
-	return nil, ErrVirtualMachineNotFound
-}
 
 func (s *ParallelsService) findVmInCacheAndSystem(ctx basecontext.ApiContext, idOrName string) (*models.ParallelsVM, error) {
 	vm, err := s.findVmSync(ctx, idOrName, true)
@@ -39,19 +19,32 @@ func (s *ParallelsService) findVmInCacheAndSystem(ctx basecontext.ApiContext, id
 func (s *ParallelsService) findVmSync(ctx basecontext.ApiContext, idOrName string, cached bool) (*models.ParallelsVM, error) {
 	var err error
 	var vms []models.ParallelsVM
+
+	findVM := func(vms []models.ParallelsVM, idOrName string) (*models.ParallelsVM, error) {
+		for _, vm := range vms {
+			if strings.EqualFold(vm.Name, idOrName) || strings.EqualFold(vm.ID, idOrName) {
+				return &vm, nil
+			}
+		}
+		return nil, ErrVirtualMachineNotFound
+	}
 	if cached {
 		vms, err = s.GetCachedVms(ctx, "")
+		if err == nil {
+			for i := 0; i < 10; i++ {
+				vm, err := findVM(vms, idOrName)
+				if err == nil {
+					return vm, nil
+				}
+				time.Sleep(500 * time.Millisecond)
+			}
+			ctx.LogInfof("VM with name or id %v not found after 10 attempts in cache", idOrName)
+			return nil, ErrVirtualMachineNotFoundInCache
+		}
 	} else {
 		vms, err = s.GetVms(ctx, "")
-	}
-
-	if err != nil {
-		return nil, err
-	}
-
-	for _, vm := range vms {
-		if strings.EqualFold(vm.Name, idOrName) || strings.EqualFold(vm.ID, idOrName) {
-			return &vm, nil
+		if err == nil {
+			return findVM(vms, idOrName)
 		}
 	}
 	ctx.LogInfof("VM with name or id %v not found with cached=%v", idOrName, cached)


### PR DESCRIPTION
# Description

- Refactored reg/unreg delete, and other vm operations now get an error if vm is not found
in cache

## Type of change
- [x] New feature (non-breaking change which adds functionality)


### Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md file accordingly
