### PR TITLE
Enhance VM Retrieval by Implementing Delayed Cache Lookup Before Fallback to Non-Cached Method

### DIFF
--- a/src/serviceprovider/parallelsdesktop/helpers.go
+++ b/src/serviceprovider/parallelsdesktop/helpers.go
@@ -2,58 +2,73 @@ package parallelsdesktop
 
 import (
 	"strings"
+	"time"
 
 	"github.com/Parallels/prl-devops-service/basecontext"
 	"github.com/Parallels/prl-devops-service/models"
 )
 
-func (s *ParallelsService) findVm(ctx basecontext.ApiContext, idOrName string, cached bool) (*models.ParallelsVM, error) {
-	var err error
-	var vms []models.ParallelsVM
-	if cached {
-		vms, err = s.GetCachedVms(ctx, "")
-	} else {
-		vms, err = s.GetVms(ctx, "")
-	}
-	if err != nil {
-		return nil, err
-	}
+const CacheFindNumberOfRetries = 10
+const CacheFindRetryDelay = 500 * time.Millisecond
 
-	for _, vm := range vms {
-		if strings.EqualFold(vm.Name, idOrName) || strings.EqualFold(vm.ID, idOrName) {
-			return &vm, nil
+func (s *ParallelsService) findVmInCacheAndSystem(ctx basecontext.ApiContext, idOrName string) (*models.ParallelsVM, error) {
+
+	for i := 0; i < CacheFindNumberOfRetries; i++ {
+		s.RLock()
+		vms := s.cachedLocalVms
+		s.RUnlock()
+		for _, vm := range vms {
+			if strings.EqualFold(vm.Name, idOrName) || strings.EqualFold(vm.ID, idOrName) {
+				return &vm, nil
+			}
+		}
+		ctx.LogInfof("VM with name or id %v not found in cache, retrying... (%d/%d)", idOrName, i+1, CacheFindNumberOfRetries)
+		time.Sleep(CacheFindRetryDelay)
+	}
+	// To fetch all virtual machines (VMs), we intentionally call `GetVms` without specifying an ID or name.
+	// This process might take some time because our goal is to refresh the entire cache.
+	// If we find any VMs, it means the current cache is outdated, and we will proceed to update it.
+	vms, err := s.GetVms(ctx, "")
+	if err == nil {
+		for _, vm := range vms {
+			if strings.EqualFold(vm.Name, idOrName) || strings.EqualFold(vm.ID, idOrName) {
+				ctx.LogWarnf("Vm is not present in cache but found in machine updating cache")
+				s.Lock()
+				s.cachedLocalVms = vms
+				s.Unlock()
+				return &vm, nil
+			}
 		}
 	}
-	ctx.LogInfof("VM with name or id %v not found with cached=%v", idOrName, cached)
 	return nil, ErrVirtualMachineNotFound
 }
 
-func (s *ParallelsService) findVmInCacheAndSystem(ctx basecontext.ApiContext, idOrName string) (*models.ParallelsVM, error) {
-	vm, err := s.findVmSync(ctx, idOrName, true)
-	if err == nil {
-		return vm, nil
-	}
-	return s.findVmSync(ctx, idOrName, false)
+func (s *ParallelsService) findVmSync(ctx basecontext.ApiContext, idOrName string) (*models.ParallelsVM, error) {
+	return s.findVmInCacheAndSystem(ctx, idOrName)
 }
 
-func (s *ParallelsService) findVmSync(ctx basecontext.ApiContext, idOrName string, cached bool) (*models.ParallelsVM, error) {
-	var err error
-	var vms []models.ParallelsVM
-	if cached {
-		vms, err = s.GetCachedVms(ctx, "")
-	} else {
-		vms, err = s.GetVms(ctx, "")
+func (s *ParallelsService) findVmWithStateInCacheAndSystem(ctx basecontext.ApiContext, idOrName string, state string) (*models.ParallelsVM, error) {
+	for i := 0; i < CacheFindNumberOfRetries; i++ {
+		s.RLock()
+		vms := s.cachedLocalVms
+		s.RUnlock()
+		for _, vm := range vms {
+			if (strings.EqualFold(vm.Name, idOrName) || strings.EqualFold(vm.ID, idOrName)) && strings.EqualFold(vm.State, state) {
+				return &vm, nil
+			}
+		}
+		ctx.LogInfof("VM with name or id %v and state %v not found in cache, retrying... (%d/%d)", idOrName, state, i+1, CacheFindNumberOfRetries)
+		time.Sleep(CacheFindRetryDelay)
 	}
-
-	if err != nil {
-		return nil, err
-	}
-
-	for _, vm := range vms {
-		if strings.EqualFold(vm.Name, idOrName) || strings.EqualFold(vm.ID, idOrName) {
+	vm, err := s.getVmForCurrentUser(ctx, idOrName)
+	if err == nil {
+		if (strings.EqualFold(vm.Name, idOrName) || strings.EqualFold(vm.ID, idOrName)) && strings.EqualFold(vm.State, state) {
+			ctx.LogWarnf("Vm with desired state is not present in cache but found in machine, updating cache")
+			go func() {
+				s.refreshCache(ctx)
+			}()
 			return &vm, nil
 		}
 	}
-	ctx.LogInfof("VM with name or id %v not found with cached=%v", idOrName, cached)
 	return nil, ErrVirtualMachineNotFound
 }

--- a/src/serviceprovider/parallelsdesktop/main.go
+++ b/src/serviceprovider/parallelsdesktop/main.go
@@ -537,7 +537,7 @@ func (s *ParallelsService) processVmAdded(ctx basecontext.ApiContext, event mode
 		return
 	}
 	for _, user := range users {
-		userMachines, err := s.GetUserVm(ctx, user.Username, event.VMID)
+		userMachines, err := s.getUserVm(ctx, user.Username, event.VMID)
 		if err != nil {
 			continue
 		}
@@ -594,7 +594,7 @@ func (s *ParallelsService) processVmUnregistered(ctx basecontext.ApiContext, eve
 
 func (s *ParallelsService) refreshCache(ctx basecontext.ApiContext) {
 	ctx.LogInfof("Refreshing Parallels VMs cache")
-	vms, err := s.getVms(ctx)
+	vms, err := s.getVmsInMachineForCurrentUser(ctx)
 	s.Lock()
 	if err != nil {
 		ctx.LogErrorf("Error refreshing Parallels VMs cache: %v", err)
@@ -605,7 +605,7 @@ func (s *ParallelsService) refreshCache(ctx basecontext.ApiContext) {
 	s.Unlock()
 }
 
-func (s *ParallelsService) GetUserVm(ctx basecontext.ApiContext, username string, vmId string) ([]models.ParallelsVM, error) {
+func (s *ParallelsService) getUserVm(ctx basecontext.ApiContext, username string, vmId string) ([]models.ParallelsVM, error) {
 	// vmId can be empty to get all VMs for the user
 	ctx.LogInfof("Getting VMs for user: %s", username)
 
@@ -614,7 +614,7 @@ func (s *ParallelsService) GetUserVm(ctx basecontext.ApiContext, username string
 	if vmId == "" {
 		ctx.LogDebugf("Getting all VMs for user %s", username)
 		var err error
-		vmIds, err = s.GetUserVmIds(ctx, username)
+		vmIds, err = s.getUserVmIds(ctx, username)
 		if err != nil {
 			return nil, err
 		}
@@ -686,7 +686,7 @@ func (s *ParallelsService) GetUserVm(ctx basecontext.ApiContext, username string
 	return userMachines, nil
 }
 
-func (s *ParallelsService) GetUserVmIds(ctx basecontext.ApiContext, username string) ([]string, error) {
+func (s *ParallelsService) getUserVmIds(ctx basecontext.ApiContext, username string) ([]string, error) {
 	cmd := helpers.Command{
 		Command: s.executable,
 		Args:    []string{"list", "-a", "-f", "--json"},
@@ -720,8 +720,8 @@ func (s *ParallelsService) GetCachedVms(ctx basecontext.ApiContext, filter strin
 		s.RLock()
 		systemMachines = s.cachedLocalVms
 		s.RUnlock()
-	} else {
-		systemMachines, err = s.getVms(ctx)
+	} else { // if not API or Orchestrator, we will not maintain the cache and get the VMs directly from the system
+		systemMachines, err = s.getVmsInMachineForCurrentUser(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -745,7 +745,7 @@ func (s *ParallelsService) GetVms(ctx basecontext.ApiContext, filter string) ([]
 	var systemMachines []models.ParallelsVM
 	var err error
 
-	systemMachines, err = s.getVms(ctx)
+	systemMachines, err = s.getVmsInMachineForCurrentUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -763,7 +763,34 @@ func (s *ParallelsService) GetVms(ctx basecontext.ApiContext, filter string) ([]
 	return filteredData, nil
 }
 
-func (s *ParallelsService) getVms(ctx basecontext.ApiContext) ([]models.ParallelsVM, error) {
+func (s *ParallelsService) getVmForCurrentUser(ctx basecontext.ApiContext, idOrName string) (models.ParallelsVM, error) {
+	ctx.LogInfof("Getting VM %s for current user without cache", idOrName)
+	users, err := s.getFilteredUsers(ctx)
+	if err != nil {
+		return models.ParallelsVM{}, err
+	}
+
+	if len(users) == 0 {
+		return models.ParallelsVM{}, errors.ErrNoSystemUserFound()
+	}
+
+	for _, user := range users {
+		userMachines, err := s.getUserVm(ctx, user.Username, idOrName)
+		if err != nil {
+			return models.ParallelsVM{}, err
+		}
+		if len(userMachines) > 0 {
+			userMachines[0].User = user.Username
+			return userMachines[0], nil
+		}
+	}
+
+	return models.ParallelsVM{}, errors.ErrNoVirtualMachineFound(idOrName)
+}
+
+// Gets all VMs for current user if the user is not root, otherwise gets all VMs for all users
+// This is non cached
+func (s *ParallelsService) getVmsInMachineForCurrentUser(ctx basecontext.ApiContext) ([]models.ParallelsVM, error) {
 	ctx.LogDebugf("Getting all VMs for all users without cache")
 	var systemMachines []models.ParallelsVM
 
@@ -777,7 +804,7 @@ func (s *ParallelsService) getVms(ctx basecontext.ApiContext) ([]models.Parallel
 	}
 
 	for _, user := range users {
-		userMachines, err := s.GetUserVm(ctx, user.Username, "")
+		userMachines, err := s.getUserVm(ctx, user.Username, "")
 		if err != nil {
 			return nil, err
 		}
@@ -801,7 +828,7 @@ func (s *ParallelsService) getVms(ctx basecontext.ApiContext) ([]models.Parallel
 }
 
 func (s *ParallelsService) GetVm(ctx basecontext.ApiContext, id string) (*models.ParallelsVM, error) {
-	vm, err := s.findVm(ctx, id, true)
+	vm, err := s.findVmInCacheAndSystem(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -810,7 +837,7 @@ func (s *ParallelsService) GetVm(ctx basecontext.ApiContext, id string) (*models
 }
 
 func (s *ParallelsService) GetVmSync(ctx basecontext.ApiContext, id string) (*models.ParallelsVM, error) {
-	vm, err := s.findVmSync(ctx, id, true)
+	vm, err := s.findVmInCacheAndSystem(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -820,7 +847,7 @@ func (s *ParallelsService) GetVmSync(ctx basecontext.ApiContext, id string) (*mo
 
 func (s *ParallelsService) SetVmState(ctx basecontext.ApiContext, id string, desiredState ParallelsVirtualMachineDesiredState,
 	flags DesiredStateFlags) error {
-	vm, err := s.findVmSync(ctx, id, true)
+	vm, err := s.findVmWithStateInCacheAndSystem(ctx, id, desiredState.String())
 	if err != nil {
 		return err
 	}
@@ -958,7 +985,7 @@ func (s *ParallelsService) PauseVm(ctx basecontext.ApiContext, id string) error 
 }
 
 func (s *ParallelsService) DeleteVm(ctx basecontext.ApiContext, id string) error {
-	vm, err := s.findVmSync(ctx, id, true)
+	vm, err := s.findVmSync(ctx, id)
 	if err != nil {
 		return err
 	}
@@ -983,7 +1010,7 @@ func (s *ParallelsService) DeleteVm(ctx basecontext.ApiContext, id string) error
 }
 
 func (s *ParallelsService) VmStatus(ctx basecontext.ApiContext, id string) (*models.VirtualMachineStatus, error) {
-	vm, err := s.findVmSync(ctx, id, true)
+	vm, err := s.findVmSync(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -1073,7 +1100,7 @@ func (s *ParallelsService) RegisterVm(ctx basecontext.ApiContext, r models.Regis
 }
 
 func (s *ParallelsService) UnregisterVm(ctx basecontext.ApiContext, r models.UnregisterVirtualMachineRequest) error {
-	vm, err := s.findVmSync(ctx, r.ID, true)
+	vm, err := s.findVmSync(ctx, r.ID)
 	if err != nil {
 		return err
 	}
@@ -1107,7 +1134,7 @@ func (s *ParallelsService) UnregisterVm(ctx basecontext.ApiContext, r models.Unr
 }
 
 func (s *ParallelsService) RenameVm(ctx basecontext.ApiContext, r models.RenameVirtualMachineRequest) error {
-	vm, err := s.findVmSync(ctx, r.GetId(), true)
+	vm, err := s.findVmSync(ctx, r.GetId())
 	if err != nil {
 		return err
 	}
@@ -1140,7 +1167,7 @@ func (s *ParallelsService) RenameVm(ctx basecontext.ApiContext, r models.RenameV
 }
 
 func (s *ParallelsService) PackVm(ctx basecontext.ApiContext, idOrName string) error {
-	vm, err := s.findVmSync(ctx, idOrName, true)
+	vm, err := s.findVmSync(ctx, idOrName)
 	if err != nil {
 		return err
 	}
@@ -1165,7 +1192,7 @@ func (s *ParallelsService) PackVm(ctx basecontext.ApiContext, idOrName string) e
 }
 
 func (s *ParallelsService) UnpackVm(ctx basecontext.ApiContext, idOrName string) error {
-	vm, err := s.findVmSync(ctx, idOrName, true)
+	vm, err := s.findVmSync(ctx, idOrName)
 	if err != nil {
 		return err
 	}
@@ -1282,7 +1309,7 @@ func (s *ParallelsService) GetUserHome(ctx basecontext.ApiContext, user string) 
 }
 
 func (s *ParallelsService) ConfigureVm(ctx basecontext.ApiContext, id string, setOperations *models.VirtualMachineConfigRequest) error {
-	vm, err := s.findVmSync(ctx, id, true)
+	vm, err := s.findVmSync(ctx, id)
 	if err != nil {
 		return err
 	}
@@ -1373,7 +1400,7 @@ func (s *ParallelsService) CreateVm(ctx basecontext.ApiContext, template data_mo
 
 func (s *ParallelsService) CreatePackerTemplateVm(ctx basecontext.ApiContext, template data_models.PackerTemplate, desiredState string) (*models.ParallelsVM, error) {
 	ctx.LogInfof("Creating Packer Virtual Machine %s", template.Name)
-	existVm, err := s.findVmSync(ctx, template.Name, true)
+	existVm, err := s.findVmSync(ctx, template.Name)
 	if existVm != nil || err != nil {
 		if errors.GetSystemErrorCode(err) != 404 {
 			return nil, errors.Newf("Machine %v with ID %v already exists and is %s", template.Name, existVm.ID, existVm.State)
@@ -1564,7 +1591,7 @@ func (s *ParallelsService) CreatePackerTemplateVm(ctx basecontext.ApiContext, te
 
 	ctx.LogInfof("Registered VM %s", destinationFolder)
 
-	existVm, err = s.findVmSync(ctx, template.Name, true)
+	existVm, err = s.findVmSync(ctx, template.Name)
 	if existVm == nil || err != nil {
 		ctx.LogErrorf("Error finding VM %s: %s", template.Name, err.Error())
 		if cleanError := helpers.RemoveFolder(repoPath); cleanError != nil {
@@ -1911,7 +1938,7 @@ func (s *ParallelsService) SetTimeSyncOperation(ctx basecontext.ApiContext, vm *
 func (s *ParallelsService) LocalUploadToVm(ctx basecontext.ApiContext, id string, r *models.VirtualMachineUploadRequest) (*models.VirtualMachineUploadResponse, error) {
 	response := models.VirtualMachineUploadResponse{}
 
-	vm, err := s.findVmSync(ctx, id, true)
+	vm, err := s.findVmSync(ctx, id)
 	if err != nil {
 		response.Error = err.Error()
 		return &response, err
@@ -2044,7 +2071,7 @@ func (s *ParallelsService) LocalUploadToVm(ctx basecontext.ApiContext, id string
 
 func (s *ParallelsService) ExecuteCommandOnVm(ctx basecontext.ApiContext, id string, r *models.VirtualMachineExecuteCommandRequest) (*models.VirtualMachineExecuteCommandResponse, error) {
 	response := &models.VirtualMachineExecuteCommandResponse{}
-	vm, err := s.findVmSync(ctx, id, true)
+	vm, err := s.findVmSync(ctx, id)
 	if err != nil {
 		ctx.LogErrorf("Error finding VM %s: %s", id, err.Error())
 		return nil, err


### PR DESCRIPTION
# Description

- We'll now check the cache several times with a delay to find a VM. If we still can’t find it, we'll then use a method that doesn't rely on the cache to retrieve it.

## Type of change

Please delete options that are not relevant.
- [X] New feature (non-breaking change which adds functionality)


### Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md file accordingly
