### PR TITLE
fix: change CompressPackLevel from pointer to int

### DIFF
--- a/src/catalog/main.go
+++ b/src/catalog/main.go
@@ -177,7 +177,7 @@ func (s *CatalogManifestService) GenerateManifestContent(r *models.PushCatalogMa
 
 	s.ns.NotifyInfof("Compressing manifest files for %v", r.CatalogId)
 	s.sendPushStepInfo(r, "Compressing manifest files")
-	packFilePath, err := s.compressMachine(r.LocalPath, manifestPackFileName, "/tmp", r.CompressPack, *r.CompressPackLevel, r.JobId, nil)
+	packFilePath, err := s.compressMachine(r.LocalPath, manifestPackFileName, "/tmp", r.CompressPack, r.CompressPackLevel, r.JobId, nil)
 	if err != nil {
 		return err
 	}
@@ -187,7 +187,7 @@ func (s *CatalogManifestService) GenerateManifestContent(r *models.PushCatalogMa
 	manifest.CompressedPath = packFilePath
 	manifest.PackFile = "/tmp/" + manifestPackFileName
 	manifest.IsCompressed = r.CompressPack
-	manifest.CompressLevel = *r.CompressPackLevel
+	manifest.CompressLevel = r.CompressPackLevel
 
 	fileInfo, err := os.Stat(packFilePath)
 	if err != nil {

--- a/src/catalog/models/push_catalog_manifest.go
+++ b/src/catalog/models/push_catalog_manifest.go
@@ -26,7 +26,7 @@ type PushCatalogManifestRequest struct {
 	Compress                bool                   `json:"compress,omitempty"`
 	CompressLevel           string                 `json:"compress_level,omitempty"`
 	CompressPack            bool                   `json:"compress_pack,omitempty"`
-	CompressPackLevel       *int                   `json:"compress_pack_level,omitempty"`
+	CompressPackLevel       int                    `json:"compress_pack_level,omitempty"`
 	Uuid                    string                 `json:"uuid,omitempty"`
 	OverrideExisting        bool                   `json:"override_existing,omitempty"`
 	RequiredRoles           []string               `json:"required_roles,omitempty"`
@@ -90,27 +90,25 @@ func (r *PushCatalogManifestRequest) Validate() error {
 
 	if r.CompressPack {
 		r.Compress = true
-		if r.CompressLevel == "" && r.CompressPackLevel == nil {
+		if r.CompressLevel == "" && r.CompressPackLevel == 0 {
 			r.CompressLevel = "balanced"
-			compressLevel := 5
-			r.CompressPackLevel = &compressLevel
+			r.CompressPackLevel = 5
 		}
 
 		if r.CompressLevel != "" {
 			compressLevel, err := helpers.ConvertCompressRatioFromString(r.CompressLevel)
 			if err != nil {
 				r.CompressLevel = "balanced"
-				compressLevel := 5
-				r.CompressPackLevel = &compressLevel
+				r.CompressPackLevel = 5
+			} else {
+				r.CompressPackLevel = compressLevel
 			}
-			r.CompressPackLevel = &compressLevel
 		}
 	}
 
 	// Set default compress pack level if not set
-	if r.CompressPackLevel == nil {
-		defaultCompressLevel := -1
-		r.CompressPackLevel = &defaultCompressLevel
+	if r.CompressPackLevel == 0 {
+		r.CompressPackLevel = -1
 	}
 
 	if helpers.ContainsIllegalChars(r.Version) {

--- a/src/catalog/push.go
+++ b/src/catalog/push.go
@@ -109,6 +109,12 @@ func (s *CatalogManifestService) Push(r *models.PushCatalogManifestRequest) *mod
 		// Validate stage
 		s.ns.StartStepf(r.JobId, constants.ActionPushValidateStage, "Validating push request for %v", r.CatalogId)
 
+		if err := r.Validate(); err != nil {
+			s.ns.FailStepf(r.JobId, constants.ActionPushValidateStage, "Validation failed for %v: %v", r.CatalogId, err)
+			manifest.AddError(err)
+			break
+		}
+
 		if err := manifest.Provider.Parse(r.Connection); err != nil {
 			s.ns.FailStepf(r.JobId, constants.ActionPushValidateStage, "Error parsing provider %v: %v", r.Connection, err)
 			manifest.AddError(err)
@@ -119,7 +125,6 @@ func (s *CatalogManifestService) Push(r *models.PushCatalogManifestRequest) *mod
 			s.ns.NotifyDebugf("Testing remote provider %v", manifest.Provider.Host)
 			apiClient.SetAuthorization(GetAuthenticator(manifest.Provider))
 		}
-
 		// // We now need to ask the provider if we already have this manifest
 		// manifestPath := filepath.Join(rs.GetProviderRootPath(s.ctx), manifest.CatalogId)
 		// exists, _ := rs.FileExists(s.ctx, manifestPath, s.getMetaFilename(manifest.Name))

--- a/src/pdfile/models/pdfile.go
+++ b/src/pdfile/models/pdfile.go
@@ -35,7 +35,7 @@ type PDFile struct {
 	CloneId                 string                        `json:"CLONE_ID,omitempty" yaml:"CLONE_ID,omitempty"`
 	IsCompressed            bool                          `json:"IS_COMPRESSED,omitempty" yaml:"IS_COMPRESSED,omitempty"`
 	CompressPack            bool                          `json:"COMPRESS_PACK,omitempty" yaml:"COMPRESS_PACK,omitempty"`
-	CompressPackLevel       *int                          `json:"COMPRESS_PACK_LEVEL,omitempty" yaml:"COMPRESS_PACK_LEVEL,omitempty"`
+	CompressPackLevel       int                           `json:"COMPRESS_PACK_LEVEL,omitempty" yaml:"COMPRESS_PACK_LEVEL,omitempty"`
 	VMType                  string                        `json:"VM_TYPE,omitempty" yaml:"VM_TYPE,omitempty"`
 	VMSize                  int64                         `json:"VM_SIZE,omitempty" yaml:"VM_SIZE,omitempty"`
 	VMRemotePath            string                        `json:"VM_REMOTE_PATH,omitempty" yaml:"VM_REMOTE_PATH,omitempty"`

--- a/src/pdfile/processors/compress_pack_level_processor.go
+++ b/src/pdfile/processors/compress_pack_level_processor.go
@@ -31,7 +31,7 @@ func (p CompressPackLevelCommandProcessor) Process(ctx basecontext.ApiContext, l
 		return false, diag
 	}
 
-	dest.CompressPackLevel = &compressLevel
+	dest.CompressPackLevel = compressLevel
 
 	ctx.LogDebugf("Processed by CompressPackLevelCommandProcessor, line %v", line)
 	return true, diag


### PR DESCRIPTION
# Description
- Fixed a nill ptr panic when the compression level is not mentioned in the PD file.
- Invoking a validate call when push is invoked via CLI, the validate call is being invoked in a REST call

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md file accordingly
