### PR TITLE
[ACE-1975]  add non-interactive kubelogin conversion to workflow

### DIFF
--- a/.github/workflows/deploy-aks.yml
+++ b/.github/workflows/deploy-aks.yml
@@ -55,6 +55,7 @@ jobs:
     name: Deploy Orchestrator
     if: ${{ inputs.deploy_orchestrator }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       id-token: write
       contents: read
@@ -83,6 +84,9 @@ jobs:
         with:
           resource-group: ${{ inputs.environment == 'stg' && vars.STG_AKS_RESOURCE_GROUP || vars.PRD_AKS_RESOURCE_GROUP }}
           cluster-name: ${{ inputs.environment == 'stg' && vars.STG_AKS_CLUSTER_NAME || vars.PRD_AKS_CLUSTER_NAME }}
+
+      - name: Convert kubeconfig for non-interactive login
+        run: kubelogin convert-kubeconfig -l azurecli
 
       - name: Setup Helm
         uses: azure/setup-helm@v4
@@ -125,6 +129,7 @@ jobs:
     name: Deploy Catalog
     if: ${{ inputs.deploy_catalog }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       id-token: write
       contents: read
@@ -153,6 +158,9 @@ jobs:
         with:
           resource-group: ${{ inputs.environment == 'stg' && vars.STG_AKS_RESOURCE_GROUP || vars.PRD_AKS_RESOURCE_GROUP }}
           cluster-name: ${{ inputs.environment == 'stg' && vars.STG_AKS_CLUSTER_NAME || vars.PRD_AKS_CLUSTER_NAME }}
+
+      - name: Convert kubeconfig for non-interactive login
+        run: kubelogin convert-kubeconfig -l azurecli
 
       - name: Setup Helm
         uses: azure/setup-helm@v4


### PR DESCRIPTION
# Description

- Convert kubeconfig to use azurecli login mode to bypass interactive browser prompts. Fixes errors in CI.
- Add a 30-minute timeout safeguard to prevent the step from hanging indefinitely.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have performed a self-review of my own code
