### PR TITLE
[ACE-1975] Use self-hosted runner for AKS deployment

### DIFF
--- a/.github/workflows/deploy-aks.yml
+++ b/.github/workflows/deploy-aks.yml
@@ -54,7 +54,7 @@ jobs:
   deploy-orchestrator:
     name: Deploy Orchestrator
     if: ${{ inputs.deploy_orchestrator }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 30
     permissions:
       id-token: write
@@ -128,7 +128,7 @@ jobs:
   deploy-catalog:
     name: Deploy Catalog
     if: ${{ inputs.deploy_catalog }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 30
     permissions:
       id-token: write


### PR DESCRIPTION
# Description

- GitHub-hosted runners cannot resolve the private AKS API endpoint. Switch to self-hosted runner with network access to the private cluster.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have performed a self-review of my own code