### PR TITLE
fix: update installation path and Jenkins version in tutorials

### DIFF
--- a/docs/_data/tutorial_devops-cli-quickstart.yml
+++ b/docs/_data/tutorial_devops-cli-quickstart.yml
@@ -265,7 +265,7 @@ steps:
           
           > **Note:** Remember to stop the daemon before making any future configuration changes.
         cmd: |
-          sudo prldevops install service /usr/bin/prldevops
+          sudo prldevops install service /usr/local/bin/prldevops
         copy_button: true
       - kind: terminal
         id: start-daemon-windows

--- a/docs/_data/tutorial_jenkins-plugin.yml
+++ b/docs/_data/tutorial_jenkins-plugin.yml
@@ -40,7 +40,7 @@ introduction:
   prerequisites:
     hard:
       - "**Parallels DevOps Service** installed and running — [Complete this tutorial first](/prl-devops-service/tutorials/tutorial_devops-cli-quickstart/)"
-      - Jenkins LTS 2.440.x or newer
+      - Jenkins LTS 2.528.3 or newer
       - JDK 17 or 21 for running Jenkins
     soft:
       - "**Catalog Service** (optional) — Only needed for catalog-based provisioning. [Setup guide](/prl-devops-service/examples/remote-catalog/)"


### PR DESCRIPTION
# Description

- Added Jenkins minimum required version in user guide

## Type of change

- [x] Documentation Change

### Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md file accordingly
