### PR TITLE
fix: correct variable reference for VM ID in CloneVirtualMachine 

### DIFF
--- a/src/orchestrator/clone_host_virtual_machine.go
+++ b/src/orchestrator/clone_host_virtual_machine.go
@@ -36,7 +36,7 @@ func (s *OrchestratorService) CloneVirtualMachine(ctx basecontext.ApiContext, vm
 		return nil, errors.NewWithCodef(400, "Host %s is not healthy", host.ID)
 	}
 
-	result, err := s.CloneHostVirtualMachine(ctx, vm.HostId, vmId, request, false)
+	result, err := s.CloneHostVirtualMachine(ctx, vm.HostId, vm.ID, request, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Description

fix: fixed cloning a VM with a name is failing in the orchestrator mode

#524 # Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run tests that prove my fix is effective or that my feature works
- [x] I have updated the CHANGELOG.md file accordingly
