### PR TITLE
Final fixed issue 530

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,13 @@ endif
 	@cd src && CGO_ENABLED=0 GOOS="windows" GOARCH="amd64" go build -ldflags="$(BASE_LDFLAGS) -X '$(VERSION_PKG).buildChannel=stable'" -o ../out/binaries/$(PACKAGE_NAME)-windows-amd64
 	@echo "Build finished."
 
+.PHONY: build-macos-arm64
+build-macos-arm64:
+	@echo "Building macOS ARM64..."							
+	mkdir -p out/binaries
+	cd src && GOOS=darwin GOARCH=arm64 go build -o ../out/binaries/prl-devops-service-darwin-arm64
+	@echo "Build finished."
+
 .PHONY: build-alpine
 build-alpine:
 	@echo "Building..."

--- a/Makefile
+++ b/Makefile
@@ -130,11 +130,11 @@ endif
 	@cd src && CGO_ENABLED=0 GOOS="windows" GOARCH="amd64" go build -ldflags="$(BASE_LDFLAGS) -X '$(VERSION_PKG).buildChannel=stable'" -o ../out/binaries/$(PACKAGE_NAME)-windows-amd64
 	@echo "Build finished."
 
-.PHONY: build-macos-arm64  
-build-macos-arm64:  
+.PHONY: build-macos-arm64
+build-macos-arm64:
 	@echo "Building macOS ARM64..."
-	mkdir -p out/binaries
-	cd src && GOOS=darwin GOARCH=arm64 go build -o ../out/binaries/prl-devops-service-darwin-arm$
+	@mkdir -p out/binaries
+	@cd src && GOOS=darwin GOARCH=arm64 go build -o ../out/binaries/prl-devops-service-darwin-arm64
 	@echo "Build finished."
 
 .PHONY: build-alpine

--- a/Makefile
+++ b/Makefile
@@ -130,11 +130,11 @@ endif
 	@cd src && CGO_ENABLED=0 GOOS="windows" GOARCH="amd64" go build -ldflags="$(BASE_LDFLAGS) -X '$(VERSION_PKG).buildChannel=stable'" -o ../out/binaries/$(PACKAGE_NAME)-windows-amd64
 	@echo "Build finished."
 
-.PHONY: build-macos-arm64
-build-macos-arm64:
-	@echo "Building macOS ARM64..."							
+.PHONY: build-macos-arm64  
+build-macos-arm64:  
+	@echo "Building macOS ARM64..."
 	mkdir -p out/binaries
-	cd src && GOOS=darwin GOARCH=arm64 go build -o ../out/binaries/prl-devops-service-darwin-arm64
+	cd src && GOOS=darwin GOARCH=arm64 go build -o ../out/binaries/prl-devops-service-darwin-arm$
 	@echo "Build finished."
 
 .PHONY: build-alpine


### PR DESCRIPTION
# Summary

Adds 'build-tacos-arm64' target to the Makefile to build macOS ARM64 binaries

# Issue

Fixes #530 -v1.0.5 has no macOS ARM64 release asset 

# Changes 

- Added:.PHONY: build-macos-arm64
build-macos-arm64:
	@echo "Building macOS ARM64..."
	@mkdir -p out/binaries
	@cd src && GOOS=darwin GOARCH=arm64 go build -o ../out/binaries/prl-devops-service-darwin-arm64
	@echo "Build finished."

# Tested 

- Build: 'make build-macos-arm64' comepleted successfully 
- Binary runs: './out/binaries/prl-devops-service0darwin-arm64 version' shows:

Parallels DevOps Service version 0.0.0 (channel:stable)

- Architecture verified 

# Note for reviewers

- This PR contains 3 commits as i kept on fixing.
- The final commit is the working version 

# Related
- Closes #530 