### PR TITLE
fix: prevent duplicate VM start during catalog machine creation

### DIFF
--- a/src/controllers/machines.go
+++ b/src/controllers/machines.go
@@ -1925,7 +1925,7 @@ func createCatalogMachine(ctx basecontext.ApiContext, request models.CreateVirtu
 		pullRequest.Architecture = request.Architecture
 	}
 
-	pullRequest.StartAfterPull = request.StartOnCreate
+	pullRequest.StartAfterPull = false
 
 	// Validate architecture and path
 	arch, err := catalog_helpers.ValidateArch(pullRequest.Architecture)

--- a/src/controllers/machines.go
+++ b/src/controllers/machines.go
@@ -1925,7 +1925,7 @@ func createCatalogMachine(ctx basecontext.ApiContext, request models.CreateVirtu
 		pullRequest.Architecture = request.Architecture
 	}
 
-	pullRequest.StartAfterPull = false
+	pullRequest.StartAfterPull = request.StartOnCreate
 
 	// Validate architecture and path
 	arch, err := catalog_helpers.ValidateArch(pullRequest.Architecture)
@@ -2017,10 +2017,6 @@ func createCatalogMachine(ctx basecontext.ApiContext, request models.CreateVirtu
 	}
 
 	if request.StartOnCreate && response.CurrentState == "stopped" {
-		err := parallelsDesktopService.StartVm(ctx, response.ID)
-		if err != nil {
-			return nil, err
-		}
 		response.CurrentState = "running"
 	}
 


### PR DESCRIPTION
# Description

- Prevent duplicate VM start during catalogue machine creation


## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have run tests that prove my fix is effective or that my feature works
- [ ] I have updated the CHANGELOG.md file accordingly
